### PR TITLE
docs: add back feedback note to main page

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -44,3 +44,11 @@ developers who have worked with TUIs will understand the nuances and benefits of
 
 We hope that this book can be a journey into creating beautiful and functional terminal-based
 applications.
+
+```admonish note
+We want to hear your feedback and suggestions.
+
+Feel free to give some suggestions on improving the book or documentation via
+[GitHub Discussions](https://github.com/ratatui-org/ratatui-book/discussions) or chat with us on
+[Discord](https://discord.com/channels/1070692720437383208/1115053951000268832).
+```


### PR DESCRIPTION
This was missed in the last push
