### PR TITLE
docs: add termion panic hook example

### DIFF
--- a/src/how-to/develop-apps/better-panic.md
+++ b/src/how-to/develop-apps/better-panic.md
@@ -100,3 +100,32 @@ In the screenshot below, I added a `None.unwrap()` into a function that is calle
 that you can see what a prettier stacktrace looks like:
 
 ![](https://user-images.githubusercontent.com/1813121/252723080-18c15640-c75f-42b3-8aeb-d4e6ce323430.png)
+
+So far we used `crossterm` for the `Tui` and panic handling. Similarly, if you are using `termion`
+you can do something like the following:
+
+```rust
+use std::panic;
+use std::error::Error;
+
+let panic_hook = panic::take_hook();
+panic::set_hook(Box::new(move |panic| {
+    let panic_cleanup = || -> Result<(), Box<dyn Error>> {
+        let mut output = io::stderr();
+        write!(
+            output,
+            "{}{}{}",
+            termion::clear::All,
+            termion::screen::ToMainScreen,
+            termion::cursor::Show
+        )?;
+        output.into_raw_mode()?.suspend_raw_mode()?;
+        io::stderr().flush()?;
+        Ok(())
+    };
+    panic_cleanup().expect("failed to clean up for panic");
+    panic_hook(panic);
+}));
+```
+
+This will take the original panic hook and execute it after cleaning up the terminal.


### PR DESCRIPTION
Hey!

I needed this for my project [systeroid](https://github.com/orhun/systeroid) (see [this commit](https://github.com/orhun/systeroid/commit/1b1aa97be4eb883ab8f3b7b27eb8396eafc60b1a))

For me, the terminal output right before handling the panic is still a bit weird but at least it is fixed afterwards and the cursor is restored.

For example, I see stuff like this if I use `better-panic`:

![](https://github.com/ratatui-org/ratatui-book/assets/24392180/65350553-76cf-4c5b-8d4c-55a4e35f6c7d)

Couldn't figure out why but wanted to share this example either way since I thought it would be useful for the book. Feel free to give feedback and move it around in the book accordingly :bear:
