### PR TITLE
docs: simplify introduction

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -17,7 +17,7 @@ or [Termwiz] to handle:
 - mouse events
 - switching to raw mode and the alternate screen
 
-Ratatui is very flexible and customizable. It does not dicate how you need to structure your
+Ratatui is very flexible and customizable. It does not dictate how you need to structure your
 application, as it is a library not a framework.
 This book covers some different options covering the range from simple single file applications
 throught more complex applications using approaches based on components, Flux and The Elm

--- a/src/README.md
+++ b/src/README.md
@@ -1,38 +1,38 @@
-# Introduction
+# Introduction to Ratatui
 
 ![Demo](https://raw.githubusercontent.com/ratatui-org/ratatui/images/examples/demo2.gif)
 
-## What is ratatui?
+[Ratatui] is a Rust library for cooking up delicious text user interfaces (TUIs). It is a
+lightweight library that provides a set of widgets and utilities to build simple or complex rust
+TUIs.
 
-`ratatui` is a [Rust](https://www.rust-lang.org/) crate that provides widgets allowing you to
-imperatively declare what the view of your application should be, and then draws those widgets
+Ratatui is an [immediate mode] graphics library. Applications imperatively declare how to render
+each frame in full by combining widgets and layout. Ratatui then draws the described UI widgets
 efficiently to the terminal.
 
-`ratatui` is based on the principle of immediate rendering. This means that at each new frame all
-widgets that are supposed to be part of the UI are re-built.
+Applications built with Ratatui use the features of their chosen [backend] ([Crossterm], [Termion],
+or [Termwiz] to handle:
 
-**The `ratatui` crate is a library and not a framework.**
+- keyboard input events
+- mouse events
+- switching to raw mode and the alternate screen
 
-It is important because `ratatui`:
-
-- does _not_ handle keyboard input events
-- does _not_ modify the state of your application
-- does _not_ dicate how you want to structure your application
-
-`ratatui` can be highly flexible and customizable. And while this can be empowering, it also puts
-the onus on developers using `ratatui` to understand how to best architect their applications, to
-tailor the experience for users as they see fit.
+Ratatui is very flexible and customizable. It does not dicate how you need to structure your
+application. as it is a library not a framework.
+This book covers some different options covering the range from simple single file applications
+throught more complex applications using approaches based on components, Flux and The Elm
+Architecture.
 
 ## Who is ratatui for?
 
-`ratatui` is designed for developers and enthusiasts who:
+Ratatui is designed for developers and enthusiasts who:
 
-- appreciate the retro aesthetic of the terminal,
 - want a lightweight alternative to graphical user interfaces (GUIs),
 - need applications that are to be deployed in constrained environments, like on servers with
   limited resources, and
 - prefer to have full control over input and events, allowing for a more customized and tailored
   user experience.
+- appreciate the retro aesthetic of the terminal,
 
 ## Who is this book for?
 
@@ -40,16 +40,34 @@ In this book, we will cover beginner guides to advanced patterns for developing 
 interfaces.
 
 Those new to the world of TUIs will find this book a comprehensive guide, introducing the
-foundational concepts and walking through common patterns of using `ratatui`. Additionally,
-developers who have worked with TUIs will understand the nuances and benefits of using `ratatui`.
+foundational concepts and walking through common patterns of using Ratatui. Additionally, developers
+who have worked with TUIs will understand the nuances and benefits of using Ratatui.
 
 We hope that this book can be a journey into creating beautiful and functional terminal-based
 applications.
 
-```admonish note
-We want to hear your feedback and suggestions.
+[immediate mode]: <https://en.wikipedia.org/wiki/Immediate_mode_(computer_graphics)>
+[backend]: ./concepts/backends
+[Ratatui]: <https://crates.io/crates/ratatui>
+[Crossterm]: <https://crates.io/crates/crossterm>
+[Termion]: <https://crates.io/crates/termion>
+[Termwiz]: <https://crates.io/crates/termwiz>
 
-Feel free to give some suggestions on improving the book or documentation via
-[GitHub Discussions](https://github.com/ratatui-org/ratatui-book/discussions) or chat with us on
-`#doc-discussion` on [Discord](https://discord.gg/pMCEU9hNEj).
+```admonish note
+Help Us Improve!
+
+We've designed this user guide to aid you throughout your journey with our open-source project.
+However, the beauty of open source is that it's not just about receiving, but also contributing. We
+highly encourage you to contribute to our project and help improve it even further. If you have
+innovative ideas, helpful feedback, or useful suggestions, please don't hesitate to share them with us.
+
+If you see something that could be better written, feel free to [create an issue], a
+[discussion thread] or even contribute a [Pull Request]. We're also often active in the
+`#doc-discussion` channel on [Discord] and [Matrix]
+
+[create an issue]: https://github.com/ratatui-org/ratatui-book/issues
+[discussion thread]: https://github.com/ratatui-org/ratatui-book/discussions
+[Pull Request]: https://github.com/ratatui-org/ratatui-book/pulls
+[Discord]: https://discord.gg/pMCEU9hNEj
+[Matrix]: https://matrix.to/#/#ratatui:matrix.org
 ```

--- a/src/README.md
+++ b/src/README.md
@@ -20,7 +20,7 @@ or [Termwiz] to handle:
 Ratatui is very flexible and customizable. It does not dictate how you need to structure your
 application, as it is a library not a framework.
 This book covers some different options covering the range from simple single file applications
-throught more complex applications using approaches based on components, Flux and The Elm
+through more complex applications using approaches based on components, Flux and The Elm
 Architecture.
 
 ## Who is ratatui for?

--- a/src/README.md
+++ b/src/README.md
@@ -18,7 +18,7 @@ or [Termwiz] to handle:
 - switching to raw mode and the alternate screen
 
 Ratatui is very flexible and customizable. It does not dicate how you need to structure your
-application. as it is a library not a framework.
+application, as it is a library not a framework.
 This book covers some different options covering the range from simple single file applications
 throught more complex applications using approaches based on components, Flux and The Elm
 Architecture.

--- a/src/README.md
+++ b/src/README.md
@@ -54,7 +54,7 @@ applications.
 [Termwiz]: <https://crates.io/crates/termwiz>
 
 ```admonish note
-Help Us Improve!
+Help us improve!
 
 We've designed this user guide to aid you throughout your journey with our open-source project.
 However, the beauty of open source is that it's not just about receiving, but also contributing. We


### PR DESCRIPTION
Simplify things a bit.
- remove first subheading to compress the vertical a bit
- remove the scary "Ratatui is not" and replace it with more positive language
- remove backticks around Ratatui - let's save those for actual code or referring to the crate
- Add more info on contributing note