### PR TITLE
docs: Remove all `as_ref()` from documentation 📚

### DIFF
--- a/src/faq/README.md
+++ b/src/faq/README.md
@@ -86,26 +86,20 @@ fn exit() -> Result<(), Box<dyn std::error::Error>> {
 fn centered_rect(r: Rect, percent_x: u16, percent_y: u16) -> Rect {
   let popup_layout = Layout::default()
     .direction(Direction::Vertical)
-    .constraints(
-      [
-        Constraint::Percentage((100 - percent_y) / 2),
-        Constraint::Percentage(percent_y),
-        Constraint::Percentage((100 - percent_y) / 2),
-      ]
-      .as_ref(),
-    )
+    .constraints([
+      Constraint::Percentage((100 - percent_y) / 2),
+      Constraint::Percentage(percent_y),
+      Constraint::Percentage((100 - percent_y) / 2),
+    ])
     .split(r);
 
   Layout::default()
     .direction(Direction::Horizontal)
-    .constraints(
-      [
-        Constraint::Percentage((100 - percent_x) / 2),
-        Constraint::Percentage(percent_x),
-        Constraint::Percentage((100 - percent_x) / 2),
-      ]
-      .as_ref(),
-    )
+    .constraints([
+      Constraint::Percentage((100 - percent_x) / 2),
+      Constraint::Percentage(percent_x),
+      Constraint::Percentage((100 - percent_x) / 2),
+    ])
     .split(popup_layout[1])[1]
 }
 

--- a/src/how-to/layout/center-a-rect.md
+++ b/src/how-to/layout/center-a-rect.md
@@ -11,26 +11,20 @@ You can use a `Vertical` layout followed by a `Horizontal` layout to get a cente
 fn centered_rect(r: Rect, percent_x: u16, percent_y: u16) -> Rect {
   let popup_layout = Layout::default()
     .direction(Direction::Vertical)
-    .constraints(
-      [
-        Constraint::Percentage((100 - percent_y) / 2),
-        Constraint::Percentage(percent_y),
-        Constraint::Percentage((100 - percent_y) / 2),
-      ]
-      .as_ref(),
-    )
+    .constraints([
+      Constraint::Percentage((100 - percent_y) / 2),
+      Constraint::Percentage(percent_y),
+      Constraint::Percentage((100 - percent_y) / 2),
+    ])
     .split(r);
 
   Layout::default()
     .direction(Direction::Horizontal)
-    .constraints(
-      [
-        Constraint::Percentage((100 - percent_x) / 2),
-        Constraint::Percentage(percent_x),
-        Constraint::Percentage((100 - percent_x) / 2),
-      ]
-      .as_ref(),
-    )
+    .constraints([
+      Constraint::Percentage((100 - percent_x) / 2),
+      Constraint::Percentage(percent_x),
+      Constraint::Percentage((100 - percent_x) / 2),
+    ])
     .split(popup_layout[1])[1]
 }
 ````

--- a/src/how-to/layout/dynamic.md
+++ b/src/how-to/layout/dynamic.md
@@ -1,6 +1,6 @@
 # Dynamic layouts
 
-With real-world applications, the content can often be dynamic. For example, a chat application may
+With real world applications, the content can often be dynamic. For example, a chat application may
 need to resize the chat input area based on the number of incoming messages. To achieve this, you
 can generate layouts dynamically:
 
@@ -10,13 +10,10 @@ fn get_layout_based_on_messages(msg_count: usize, f: &Frame) -> Vec<Rect> {
 
     Layout::default()
         .direction(Direction::Vertical)
-        .constraints(
-            [
-                Constraint::Percentage(msg_percentage),
-                Constraint::Percentage(100 - msg_percentage),
-            ]
-            .as_ref(),
-        )
+        .constraints([
+            Constraint::Percentage(msg_percentage),
+            Constraint::Percentage(100 - msg_percentage),
+        ])
         .split(f.size())
 }
 ```
@@ -42,13 +39,10 @@ match action {
 
 let chunks = Layout::default()
     .direction(Direction::Horizontal)
-    .constraints(
-        [
-            Constraint::Percentage(current_percentage),
-            Constraint::Percentage(100 - current_percentage),
-        ]
-        .as_ref(),
-    )
+    .constraints([
+        Constraint::Percentage(current_percentage),
+        Constraint::Percentage(100 - current_percentage),
+    ])
     .split(f.size());
 
 ```


### PR DESCRIPTION
Fixes #94 