### PR TITLE
JSON editor example edits

### DIFF
--- a/src/tutorial/json-editor/ratatui-json-editor-app/src/ui.rs
+++ b/src/tutorial/json-editor/ratatui-json-editor-app/src/ui.rs
@@ -155,8 +155,8 @@ pub fn ui<B: Backend>(f: &mut Frame<B>, app: &App) {
 
         let value_text = Paragraph::new(app.value_input.clone()).block(value_block);
         f.render_widget(value_text, popup_chunks[1]);
-        // ANCHOR_END: key_value_blocks
     }
+    // ANCHOR_END: key_value_blocks
 
     // ANCHOR: exit_screen
     if let CurrentScreen::Exiting = app.current_screen {

--- a/src/tutorial/json-editor/ui-exit.md
+++ b/src/tutorial/json-editor/ui-exit.md
@@ -12,4 +12,4 @@ in the `stdout` pipe, or close without outputting anything.
 
 The only thing in this part that we haven't done before, is use the `Clear` widget. This is a
 special widget that does what the name suggests --- it clears everything in the space it is
-rendered. In this case, it clears all of the menu that was prerendered behind it.
+rendered.

--- a/src/tutorial/json-editor/ui-exit.md
+++ b/src/tutorial/json-editor/ui-exit.md
@@ -10,6 +10,7 @@ in the `stdout` pipe, or close without outputting anything.
 {{#include ./ratatui-json-editor-app/src/ui.rs:exit_screen}}
 ```
 
-The only thing in this part that we haven't done before, is use the `Clear` widget. This is a
+The only thing in this part that we haven't done before, is use the 
+[`Clear`](https://docs.rs/ratatui/latest/ratatui/widgets/struct.Clear.html) widget. This is a
 special widget that does what the name suggests --- it clears everything in the space it is
 rendered.


### PR DESCRIPTION
This makes a couple of small changes to the JSON editor example app:

* Include the closing brace in the main UI rendering page, which closes #95.
* Remove a redundant sentence which was a little confusing (see commit msg.)

I won't be in the slightest bit offended if you prefer to remove the second change, or do it differently.