### PR TITLE
fix: broken links 🐛

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -57,6 +57,7 @@ export default defineConfig({
         },
         {
           label: "Tutorial",
+          collapsed: true,
           items: [
             {
               label: "Hello World",
@@ -76,6 +77,7 @@ export default defineConfig({
                 },
                 {
                   label: "Multiple Files",
+                  collapsed: true,
                   items: [
                     {
                       label: "Introduction",
@@ -127,6 +129,7 @@ export default defineConfig({
                 },
                 {
                   label: "Ui.rs",
+                  collapsed: true,
                   items: [
                     { label: "UI", link: "/tutorial/json-editor/ui" },
                     { label: "Ui.rs - Main", link: "/tutorial/json-editor/ui-main" },
@@ -174,6 +177,7 @@ export default defineConfig({
         },
         {
           label: "Concepts",
+          collapsed: true,
           items: [
             {
               label: "Layout",
@@ -241,6 +245,7 @@ export default defineConfig({
         },
         {
           label: "How To",
+          collapsed: true,
           items: [
             {
               label: "Layout UIs",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -49,11 +49,11 @@ export default defineConfig({
       sidebar: [
         {
           label: "Introduction",
-          link: "/introduction/",
+          link: "/introduction",
         },
         {
           label: "Installation",
-          link: "/installation/",
+          link: "/installation",
         },
         {
           label: "Tutorial",
@@ -61,7 +61,7 @@ export default defineConfig({
           items: [
             {
               label: "Hello World",
-              link: "/tutorial/hello-world/",
+              link: "/tutorial/hello-world",
             },
             {
               label: "Counter App",

--- a/src/content/docs/concepts/application-patterns/component-architecture.md
+++ b/src/content/docs/concepts/application-patterns/component-architecture.md
@@ -14,7 +14,7 @@ We also have a `ratatui-async-template` that has an example of this `Component` 
 
 - <https://github.com/ratatui-org/ratatui-async-template>
 
-We already covered [TEA](./the-elm-architecture) in the previous section. The `Component`
+We already covered [TEA](./../the-elm-architecture) in the previous section. The `Component`
 architecture takes a slightly more object oriented trait based approach.
 
 Each component encapsulates its own state, event handlers, and rendering logic.

--- a/src/content/docs/concepts/application-patterns/the-elm-architecture.md
+++ b/src/content/docs/concepts/application-patterns/the-elm-architecture.md
@@ -299,7 +299,7 @@ When you put it all together, your main application loop might look something li
 
 This cycle repeats, ensuring your TUI is always up-to-date with user interactions.
 
-As an illustrative example, here's the [Counter App](../../tutorial/counter-app/single-function)
+As an illustrative example, here's the [Counter App](../../../tutorial/counter-app/single-function)
 refactored using TEA.
 
 The notable difference from before is that we have an `Model` struct that captures the app state,

--- a/src/content/docs/highlights/v0.21.md
+++ b/src/content/docs/highlights/v0.21.md
@@ -312,7 +312,7 @@ applications built with `ratatui`!
 ## Migration from `tui-rs`
 
 We put together a migration guide at the Wiki:
-[Migrating from TUI](./../../how-to/develop-apps/migrate-from-tui-rs)
+[Migrating from TUI](../../how-to/develop-apps/migrate-from-tui-rs)
 
 Also, the minimum supported Rust version is `1.65.0`
 

--- a/src/content/docs/highlights/v0.21.md
+++ b/src/content/docs/highlights/v0.21.md
@@ -312,7 +312,7 @@ applications built with `ratatui`!
 ## Migration from `tui-rs`
 
 We put together a migration guide at the Wiki:
-[Migrating from TUI](./../how-to/develop-apps/migrate-from-tui-rs)
+[Migrating from TUI](./../../how-to/develop-apps/migrate-from-tui-rs)
 
 Also, the minimum supported Rust version is `1.65.0`
 

--- a/src/content/docs/how-to/develop-apps/better-panic-hooks.md
+++ b/src/content/docs/how-to/develop-apps/better-panic-hooks.md
@@ -31,7 +31,7 @@ pub fn initialize_panic_handler() {
 }
 ```
 
-I personally like to reuse the [`Tui`](./abstract-terminal-and-event-handler) struct in the panic
+I personally like to reuse the [`Tui`](../abstract-terminal-and-event-handler) struct in the panic
 handler. That way, if I ever decide to move from `crossterm` to `termion` in the future, there's one
 less place in the project that I have to worry about refactoring.
 

--- a/src/content/docs/how-to/develop-apps/cli-arguments.md
+++ b/src/content/docs/how-to/develop-apps/cli-arguments.md
@@ -60,7 +60,7 @@ Data directory: {data_dir_path}"
 ```
 
 This function uses the `get_data_dir()` and `get_config_dir()` from
-[the section on XDG directories](./config-directories).
+[the section on XDG directories](../config-directories).
 
 This function also makes use of an environment variable `RATATUI_TEMPLATE_GIT_INFO` to derive the
 Git commit hash. The variable can be populated during the build process by `build.rs`:

--- a/src/content/docs/how-to/develop-apps/config-directories.md
+++ b/src/content/docs/how-to/develop-apps/config-directories.md
@@ -34,7 +34,7 @@ Specification.
 4. A good practice is to notify the user about the location of the configuration and data
    directories. An example from the template is to print out these locations when the user invokes
    the `--version` command-line argument. See the section on
-   [Command line argument parsing](./../cli-arguments)
+   [Command line argument parsing](../cli-arguments)
 
 Here's an example `get_data_dir()` and `get_config_dir()` functions for your reference:
 

--- a/src/content/docs/how-to/develop-apps/config-directories.md
+++ b/src/content/docs/how-to/develop-apps/config-directories.md
@@ -34,7 +34,7 @@ Specification.
 4. A good practice is to notify the user about the location of the configuration and data
    directories. An example from the template is to print out these locations when the user invokes
    the `--version` command-line argument. See the section on
-   [Command line argument parsing](./cli-arguments)
+   [Command line argument parsing](./../cli-arguments)
 
 Here's an example `get_data_dir()` and `get_config_dir()` functions for your reference:
 

--- a/src/content/docs/how-to/develop-apps/logging-with-tracing.md
+++ b/src/content/docs/how-to/develop-apps/logging-with-tracing.md
@@ -101,7 +101,7 @@ The log level is decided by the `${YOUR_CRATE_NAME}_LOGLEVEL` environment variab
 `log::LevelFilter::Info`).
 
 Additionally, the location of the log files would be decided by your environment variables. See
-[the section on XDG directories](./config-directories) for more information.
+[the section on XDG directories](../config-directories) for more information.
 
 :::tip
 

--- a/src/content/docs/how-to/layout/collapse-borders.md
+++ b/src/content/docs/how-to/layout/collapse-borders.md
@@ -71,7 +71,7 @@ If this sounds too complex, we're looking for some help to make this easier in
 :::
 
 The full code for this example is available at
-<https://github.com/ratatui-org/ratatui-book/code/how-to-collapse-borders>
+<https://github.com/ratatui-org/ratatui-book/blob/main/code/how-to-collapse-borders>
 
 Full `ui()` function:
 

--- a/src/content/docs/installation.md
+++ b/src/content/docs/installation.md
@@ -72,4 +72,4 @@ ratatui = { version = "0.23", default-features = false, features = ["termwiz"] }
 termwiz = "0.20.0"
 ```
 
-[Backend]: ./concepts/backends/
+[Backend]: ../concepts/backends

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -48,7 +48,7 @@ We hope that this book can be a journey into creating beautiful and functional t
 applications.
 
 [immediate mode]: https://en.wikipedia.org/wiki/Immediate_mode_(computer_graphics)
-[backend]: ./concepts/backends
+[backend]: ./../concepts/backends
 [Ratatui]: https://crates.io/crates/ratatui
 [Crossterm]: https://crates.io/crates/crossterm
 [Termion]: https://crates.io/crates/termion

--- a/src/content/docs/tutorial/counter-app/multiple-files/event.md
+++ b/src/content/docs/tutorial/counter-app/multiple-files/event.md
@@ -175,8 +175,8 @@ This gives us a `sender` and `receiver` pair. The `sender` can be used to send e
 Notice that we are using `std::thread::spawn` in this `EventHandler`. This thread is spawned to
 handle events and runs in the background and is responsible for polling and sending events to our
 main application through the channel. In the
-[async counter tutorial](./../counter-async-app/async-event-stream) we will use `tokio::task::spawn`
-instead.
+[async counter tutorial](./../../counter-async-app/async-event-stream) we will use
+`tokio::task::spawn` instead.
 
 In this background thread, we continuously poll for events with `event::poll(timeout)`. If an event
 is available, it's read and sent through the sender channel. The types of events we handle include,

--- a/src/content/docs/tutorial/counter-app/multiple-files/event.md
+++ b/src/content/docs/tutorial/counter-app/multiple-files/event.md
@@ -175,7 +175,7 @@ This gives us a `sender` and `receiver` pair. The `sender` can be used to send e
 Notice that we are using `std::thread::spawn` in this `EventHandler`. This thread is spawned to
 handle events and runs in the background and is responsible for polling and sending events to our
 main application through the channel. In the
-[async counter tutorial](./../../counter-async-app/async-event-stream) we will use
+[async counter tutorial](../../counter-async-app/async-event-stream) we will use
 `tokio::task::spawn` instead.
 
 In this background thread, we continuously poll for events with `event::poll(timeout)`. If an event

--- a/src/content/docs/tutorial/counter-app/multiple-files/index.md
+++ b/src/content/docs/tutorial/counter-app/multiple-files/index.md
@@ -67,7 +67,7 @@ fn main() -> Result<()> {
 ```
 
 `color_eyre` is an error report handler for colorful, consistent, and well formatted error reports
-for all kinds of errors. Check out the [section](../../how-to/develop-apps/setup-panic-hooks) for
+for all kinds of errors. Check out the [section](../../../how-to/develop-apps/setup-panic-hooks) for
 setting up panic hooks with color-eyre.
 
 :::

--- a/src/content/docs/tutorial/counter-app/multiple-files/index.md
+++ b/src/content/docs/tutorial/counter-app/multiple-files/index.md
@@ -67,9 +67,8 @@ fn main() -> Result<()> {
 ```
 
 `color_eyre` is an error report handler for colorful, consistent, and well formatted error reports
-for all kinds of errors. Check out the
-[section](../../how-to/develop-apps/setup-panic-hooks-color-eyre) for setting up panic hooks with
-color-eyre.
+for all kinds of errors. Check out the [section](../../how-to/develop-apps/setup-panic-hooks) for
+setting up panic hooks with color-eyre.
 
 :::
 

--- a/src/content/docs/tutorial/counter-app/multiple-files/main.md
+++ b/src/content/docs/tutorial/counter-app/multiple-files/main.md
@@ -45,7 +45,7 @@ Sleep 2.5s
 ![Counter app demo](https://user-images.githubusercontent.com/1813121/263404720-41bd81a0-4eec-479c-9333-44363a183613.gif)
 
 You can find the full source code for this multiple files tutorial here:
-<https://github.com/ratatui-org/ratatui.rs/tree/main/src/tutorial/counter-app/ratatui-counter-app>.
+<https://github.com/ratatui-org/ratatui.rs/tree/main/code/ratatui-counter-app>.
 
 :::note[Homework]
 

--- a/src/content/docs/tutorial/counter-app/multiple-files/update.md
+++ b/src/content/docs/tutorial/counter-app/multiple-files/update.md
@@ -13,7 +13,7 @@ Finally we have the `update.rs` file. Here, the `update()` function takes in two
 ```
 
 Note that here we don't have to check that `key_event.kind` is `KeyEventKind::Press` because we
-already do that check in [event.rs](./event) and only send `KeyEventKind::Press` events on the
+already do that check in [event.rs](./../event) and only send `KeyEventKind::Press` events on the
 channel.
 
 :::note[Homework]
@@ -21,7 +21,7 @@ channel.
 As an exercise, can you refactor this app to use "The Elm Architecture" principles?
 
 Check out
-[the concepts page on The Elm Architecture](./../../../concepts/application-patterns/the-elm-architecture)
+[the concepts page on The Elm Architecture](../../../concepts/application-patterns/the-elm-architecture)
 for reference.
 
 :::

--- a/src/content/docs/tutorial/counter-app/multiple-files/update.md
+++ b/src/content/docs/tutorial/counter-app/multiple-files/update.md
@@ -20,7 +20,8 @@ channel.
 
 As an exercise, can you refactor this app to use "The Elm Architecture" principles?
 
-Check out [the concepts page on The Elm Architecture](./../../concepts/the-elm-architecture) for
-reference.
+Check out
+[the concepts page on The Elm Architecture](./../../../concepts/application-patterns/the-elm-architecture)
+for reference.
 
 :::

--- a/src/content/docs/tutorial/counter-app/single-function.md
+++ b/src/content/docs/tutorial/counter-app/single-function.md
@@ -140,7 +140,7 @@ to render a widget, i.e. a `Paragraph` widget.
 
 The closure passed to the `Terminal::draw()` method must render the entire UI. Call the draw method
 at most once for each pass through your application's main loop.
-[See the FAQ for more information.](./../../faq/)
+[See the FAQ for more information.](./../../../faq)
 
 :::
 

--- a/src/content/docs/tutorial/counter-async-app/async-event-stream.md
+++ b/src/content/docs/tutorial/counter-async-app/async-event-stream.md
@@ -2,8 +2,9 @@
 title: Async Event Stream
 ---
 
-Previously, in the multiple file version of the counter app, in [`event.rs`](./../counter-app/event)
-we created an `EventHandler` using `std::thread::spawn`, i.e. OS threads.
+Previously, in the multiple file version of the counter app, in
+[`event.rs`](../counter-app/multiple-files/event) we created an `EventHandler` using
+`std::thread::spawn`, i.e. OS threads.
 
 In this section, we are going to do the same thing with "green" threads or tasks, i.e. rust's
 `async`-`await` features + a future executor. We will be using `tokio` for this.

--- a/src/content/docs/tutorial/counter-async-app/conclusion.md
+++ b/src/content/docs/tutorial/counter-async-app/conclusion.md
@@ -10,7 +10,7 @@ specific async operations concurrently.
 There's more information in
 [`ratatui-async-template`](https://github.com/ratatui-org/ratatui-async-template) about structuring
 an `async` application. The template also covers setting up a
-[`Component` based architecture](../../concepts/application-patterns/component-architecture).
+[`Component` based architecture](../../../concepts/application-patterns/component-architecture).
 
 For more information, refer to the documentation for the template:
 <https://ratatui-org.github.io/ratatui-async-template/>

--- a/src/content/docs/tutorial/counter-async-app/full-async-events.md
+++ b/src/content/docs/tutorial/counter-async-app/full-async-events.md
@@ -23,8 +23,8 @@ are also going to include a few more `Event` variants for making our application
 
 Below is the relevant snippet of an updated `Tui` struct. You can click on the "Show hidden lines"
 button at the top right of the code block or check out
-[this section of the book](../../../how-to/develop-apps/abstract-terminal-and-event-handler) for the
-full version this struct.
+[this section of the book](../../../how-to/develop-apps/terminal-and-event-handler) for the full
+version this struct.
 
 The key things to note are that we create a `tick_interval`, `render_interval` and `reader` stream
 that can be polled using `tokio::select!`. This means that even while waiting for a key press, we

--- a/src/content/docs/tutorial/counter-async-app/full-async-events.md
+++ b/src/content/docs/tutorial/counter-async-app/full-async-events.md
@@ -23,7 +23,7 @@ are also going to include a few more `Event` variants for making our application
 
 Below is the relevant snippet of an updated `Tui` struct. You can click on the "Show hidden lines"
 button at the top right of the code block or check out
-[this section of the book](../../how-to/develop-apps/abstract-terminal-and-event-handler) for the
+[this section of the book](../../../how-to/develop-apps/abstract-terminal-and-event-handler) for the
 full version this struct.
 
 The key things to note are that we create a `tick_interval`, `render_interval` and `reader` stream

--- a/src/content/docs/tutorial/hello-world.md
+++ b/src/content/docs/tutorial/hello-world.md
@@ -154,7 +154,7 @@ First let's add the module imports necessary to run our application.
 - From `std` we import the `io::Result` which most of the backend methods return, and the `stdout()`
   method.
 
-:::info
+:::note
 
 Ratatui has a [`prelude`](https://docs.rs/ratatui/latest/ratatui/prelude/index.html) module that
 re-exports the most used types and traits. Importing this module with a wildcard import can simplify
@@ -192,7 +192,7 @@ Replace the existing `main` function with the following:
 {{#include @code/hello-world-tutorial/src/main.rs:restore}}
 ```
 
-:::warning
+:::caution
 
 If we don't disable raw mode before exit, terminals can act weirdly when the mouse or navigation
 keys are pressed. To fix this, on a Linux / macOS terminal type `reset`. On Windows, you'll have to

--- a/src/content/docs/tutorial/json-editor/app.md
+++ b/src/content/docs/tutorial/json-editor/app.md
@@ -119,4 +119,4 @@ pairs.
 ```
 
 <!-- prettier-ignore -->
-[^note]: In ratatui, every frame draws the UI anew. See the [Rendering section](./../../concepts/rendering) for more information.
+[^note]: In ratatui, every frame draws the UI anew. See the [Rendering section](./../../../concepts/rendering) for more information.

--- a/src/content/docs/tutorial/json-editor/app.md
+++ b/src/content/docs/tutorial/json-editor/app.md
@@ -119,4 +119,4 @@ pairs.
 ```
 
 <!-- prettier-ignore -->
-[^note]: In ratatui, every frame draws the UI anew. See the [Rendering section](./../../../concepts/rendering) for more information.
+[^note]: In ratatui, every frame draws the UI anew. See the [Rendering section](../../../concepts/rendering) for more information.

--- a/src/content/docs/tutorial/json-editor/closing-thoughts.md
+++ b/src/content/docs/tutorial/json-editor/closing-thoughts.md
@@ -5,14 +5,15 @@ title: Closing Thoughts
 This tutorial should get you started with a basic understanding of the flow of a `ratatui` program.
 However, this is only _one_ way to create a `ratatui` application. Because `ratatui` is relatively
 low level compared to other UI frameworks, almost any application model can be implemented. You can
-explore more of these in [Concepts: Application Patterns](../../concepts/application-patterns/) and
-get some inspiration for what model will work best for your application.
+explore more of these in
+[Concepts: Application Patterns](../../concepts/application-patterns/the-elm-architecture) and get
+some inspiration for what model will work best for your application.
 
 ## Finished Files
 
 You can find the finished project used for the tutorial on
-[GitHub](https://github.com/ratatui-org/ratatui.rs/tree/main/src/tutorial/json-editor). The code is
-also shown at the bottom of this page.
+[GitHub](https://github.com/ratatui-org/ratatui.rs/tree/main/code/ratatui-json-editor-app). The code
+is also shown at the bottom of this page.
 
 You can test this application by yourself by running:
 

--- a/src/content/docs/tutorial/json-editor/main.md
+++ b/src/content/docs/tutorial/json-editor/main.md
@@ -4,7 +4,7 @@ title: Main.rs
 
 The `main` file in many ratatui applications is simply a place to store the startup loop, and
 occasionally event handling. See more ways to handle events in
-[Event Handling](../../concepts/event-handling)
+[Event Handling](../../../concepts/event-handling)
 
 In this application, we will be using our `main` function to run the startup steps, and start the
 main loop. We will also put our main loop logic and event handling in this file.

--- a/src/content/docs/tutorial/json-editor/ui-main.md
+++ b/src/content/docs/tutorial/json-editor/ui-main.md
@@ -51,7 +51,7 @@ simply want the user to be able to see what they have already entered.
 ```
 
 For more information on Line, Span, and Style see
-[How-To: Displaying Text](../../how-to/render/display-text)
+[How-To: Displaying Text](../../../how-to/render/display-text)
 
 In this piece of the function, we create a vector of `ListItem`s, and populate it with styled and
 formatted key-value pairs. Finally, we create the `List` widget, and render it.

--- a/src/content/docs/tutorial/json-editor/ui-main.md
+++ b/src/content/docs/tutorial/json-editor/ui-main.md
@@ -22,8 +22,8 @@ corner of their space, and their size. We will use these later, after we prepare
 The title is an important piece for any application. It helps the user understand what they can do
 and where they are. To create our title, we are going to use a `Paragraph` widget (which is used to
 display only text), and we are going to tell that `Paragraph` we want a border all around it by
-giving it a `Block` with borders enabled. See [How-To: Block](../../how-to/widgets/block) and
-[How-To: Paragraph](../../how-to/widgets/paragraph) for more information about `Block` and
+giving it a `Block` with borders enabled. See [How-To: Block](../../../how-to/widgets/block) and
+[How-To: Paragraph](../../../how-to/widgets/paragraph) for more information about `Block` and
 `Paragraph`.
 
 ```rust
@@ -32,9 +32,9 @@ giving it a `Block` with borders enabled. See [How-To: Block](../../how-to/widge
 
 In this code, the first thing we do, is create a `Block` with all borders enabled, and the default
 style. Next, we created a paragraph widget with the text "Create New Json" styled green. See
-[How-To: Paragraphs](../../how-to/widgets/paragraph) for more information about creating paragraphs
-and [How-To: Styling-Text](../../how-to/render/style-text) for styling text. Finally, we call
-`render_widget` on our `Frame`, and give it the widget we want to render it, and the `Rect`
+[How-To: Paragraphs](../../../how-to/widgets/paragraph) for more information about creating
+paragraphs and [How-To: Styling-Text](../../../how-to/render/style-text) for styling text. Finally,
+we call `render_widget` on our `Frame`, and give it the widget we want to render it, and the `Rect`
 representing where it needs to go and what size it should be. (this is the way all widgets are
 drawn)
 


### PR DESCRIPTION
The issue here is when astro sees `src/content/docs/path/to/filename.md` it renders `path/to/filename/index.html`.

In `path/to/filename.md`, linking to `path/to/filename2.md` is usually done by `./filename2.md` but for the path to work in the web it has to be `./../filename`.

An alternative solution here would be to have _every_ file named `index.md` in the appropriate folders. Then the relative paths will always match correctly.