### PR TITLE
docs: Add `fzf-make` to showcase

### DIFF
--- a/src/content/docs/showcase.md
+++ b/src/content/docs/showcase.md
@@ -2,6 +2,14 @@
 title: Showcase
 ---
 
+## [`fzf-make`](https://github.com/kyu08/fzf-make)
+
+A command line tool that executes make target using fuzzy finder with preview window
+
+![demo gif of fzf-make](https://raw.githubusercontent.com/kyu08/fzf-make/main/static/demo.gif)
+
+---
+
 ## [`scope-tui`](https://github.com/alemidev/scope-tui)
 
 A simple oscilloscope/vectorscope/spectroscope for your terminal


### PR DESCRIPTION
I created a command line tool that executes make target using fuzzy finder with preview window using `ratatui`!

https://github.com/kyu08/fzf-make

If you don't mind, I would like to add `fzf-make` on showcase :)

(By the way, new `ratatui`'s web site is awesome!)

![](https://raw.githubusercontent.com/kyu08/fzf-make/main/static/demo.gif)