### PR TITLE
Add TOML support to code import plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "sharp": "^0.32.5",
         "starlight-links-validator": "^0.4.2",
         "tailwindcss": "^3.3.5",
-        "typescript": "^5.3.2"
+        "typescript": "^5.3.2",
+        "verbose-regexp": "^3.0.0"
       },
       "devDependencies": {
         "husky": "^8.0.0",
@@ -9969,6 +9970,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/verbose-regexp": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/verbose-regexp/-/verbose-regexp-3.0.0.tgz",
+      "integrity": "sha512-tjWrhhwvnbK8z82/RZ0BrZ9CqNy8qo9cdzhtE20yqHxtRSq/nGHeX7fItvpf7pi8jKXo9V1ja5+o36VKXN3mEg==",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/vfile": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "sharp": "^0.32.5",
     "starlight-links-validator": "^0.4.2",
     "tailwindcss": "^3.3.5",
-    "typescript": "^5.3.2"
+    "typescript": "^5.3.2",
+    "verbose-regexp": "^3.0.0"
   },
   "devDependencies": {
     "husky": "^8.0.0",

--- a/src/plugin/remark-code-import.ts
+++ b/src/plugin/remark-code-import.ts
@@ -66,9 +66,9 @@ const remarkIncludeCode = () => {
 
 export default remarkIncludeCode;
 
-function include(indludePath: string, anchor?: string): string {
+function include(includePath: string, anchor?: string): string {
   try {
-    let fileContent = fs.readFileSync(indludePath, "utf8");
+    let fileContent = fs.readFileSync(includePath, "utf8");
 
     // if the anchor is in the format "start:end", extract the lines between the start and end
     if (anchor && anchor.search(":") != -1) {
@@ -107,7 +107,7 @@ function include(indludePath: string, anchor?: string): string {
         ${endAnchorRegex}         // matches the end anchor
       `;
       const anchorContent = fileContent.match(anchorRegex)?.groups?.content;
-      if (!anchorContent) throw new Error(`Anchor '${anchor}' not found in ${indludePath}`);
+      if (!anchorContent) throw new Error(`Anchor '${anchor}' not found in ${includePath}`);
       fileContent = anchorContent;
     }
     // Remove lines containing start and end anchor comments
@@ -117,9 +117,9 @@ function include(indludePath: string, anchor?: string): string {
       .join("\n");
   } catch (err) {
     if (err instanceof Error) {
-      throw new Error(`Error reading file '${indludePath}': ${err.message}`);
+      throw new Error(`Error reading file '${includePath}': ${err.message}`);
     } else {
-      throw new Error(`Error reading file '${indludePath}': ${err}`);
+      throw new Error(`Error reading file '${includePath}': ${err}`);
     }
   }
 }

--- a/src/plugin/remark-code-import.ts
+++ b/src/plugin/remark-code-import.ts
@@ -3,120 +3,60 @@ import path from "path";
 import type { Node } from "unist";
 import { visit } from "unist-util-visit";
 import type { VFile } from "vfile";
+import { rx } from 'verbose-regexp' // https://www.npmjs.com/package/verbose-regexp
 
 interface CodeNode extends Node {
   lang?: string;
   value: string;
 }
 
+// Regular expression to match custom include directives in the format:
+// {{#include filepath[:anchor]}}
+//
+// Example matches:
+// - {{#include path/to/file}} - Matches "path/to/file" as the filepath.
+// - {{#include path/to/file:anchorName}} - Matches "path/to/file" as the filepath and "anchorName" as the anchor.
+// - {{#include ../../path/to/file}} - relative path to file from current markdown file
+// - {{#include @path/to/file}} - path to file from root directory
+const pathRegex = rx`(?<path>.+?)`;         // Matches at least one character, but as few as possible
+const anchorNameRegex = rx`(?<anchor>.*?)`; // Matches at least one character, but as few as possible
+const includeRegex = rx.g`  // global (matches all instances in the file)
+  \{\{                      // literal "{{"
+  \s*                       // optional whitespace
+  #include                  // literal "#include"
+  \s*                       // optional whitespace
+  ${pathRegex}              // filepath
+  (:${anchorNameRegex})?  // optional anchor name
+  \s*                       // optional whitespace after anchor
+  \}\}                      // literal "}}"
+`;
+
 const remarkIncludeCode = () => {
   // The plugin function, working with a Markdown tree and associated file
-  return (tree: Node, file: VFile) => {
+  return (tree: Node, markdownFile: VFile) => {
     // Visit each 'code' node in the Markdown AST
     visit(tree, "code", (node: CodeNode) => {
-      // Regular expression to match custom include directives in the format:
-      // {{#include filepath[:anchor]}}
-      //
-      // Explanation of the regex pattern:
-      //
-      // \{ - Escapes the '{' character because it has a special meaning in regex.
-      //     We need two \{ to represent the two '{' in our target string.
-      // #include - Matches the literal string "#include", which is part of our directive.
-      // (.*?) - A non-greedy match for any characters. This is the first capturing group
-      //         and it captures the filepath. The non-greedy `.*?` ensures that it captures
-      //         the minimum number of characters until it reaches the next part of the pattern.
-      //         It stops at the first colon (:) it encounters, or the end of the curly braces
-      //         if there is no colon.
-      // (?: - Starts a non-capturing group for the optional anchor part. The non-capturing
-      //      group is used here because we don't need to capture the ':' itself, just the part after it.
-      // : - Matches the literal colon character. This separates the filepath and the optional anchor.
-      // (.*?) - Another non-greedy match for any characters. This is the second capturing group
-      //         and it captures the anchor. As it's non-greedy, it stops at the first '}' it encounters.
-      // )? - The entire non-capturing group is made optional by the '?', which means this part of the
-      //      pattern (the colon and the anchor) might not be present.
-      // \} - Escapes the '}' character. Like the '{', we need two \} to represent the two '}' in our target string.
-      // /g - Global flag, meaning it will match all occurrences in the string, not just the first one.
-      //
-      // Example matches:
-      // "{{#include path/to/file}}" - Matches and captures "path/to/file" as the filepath.
-      // "{{#include path/to/file:anchorName}}" - Matches and captures "path/to/file" as the filepath
-      //                                          and "anchorName" as the anchor.
-      // "{{#include ../../path/to/file}}" - relative path to file from current markdown file
-      // "{{#include @path/to/file}}" - path to file from root directory
-      const includeRegex = /\{\{#include (.*?)(?::(.*?))?\}\}/g;
       let match;
       // There can be multiple includes in a code block
       // Perform matches one by one, replacing text in AST along the way
       while ((match = includeRegex.exec(node.value)) !== null) {
-        const filePath = match[1];
-        const anchor = match[2];
-        let fullPath;
-        if (filePath.startsWith("@")) {
+        try {
+          const includePath = match.groups?.path;
+          const anchor = match.groups?.anchor;
+          if (!includePath) { throw new Error("No file path specified"); }
           // Inspired by astro aliases: https://docs.astro.build/en/guides/aliases/
           // Allows for specifying path from root directory
-          fullPath = filePath.replace("@", "./");
-        } else {
-          fullPath = path.resolve(path.dirname(file.path), filePath);
-        }
-        try {
-          let fileContent = fs.readFileSync(fullPath, "utf8");
-          if (anchor && anchor.search(":") != -1) {
-            const extrema = anchor.split(":");
-            const lines = fileContent.split("\n");
-            const startLine = extrema[0];
-            const endLine = extrema[1];
-            const startIdx = startLine ? parseInt(startLine) - 1 : 0;
-            const endIdx = endLine ? parseInt(endLine) : lines.length;
-            fileContent = lines.slice(startIdx, endIdx).join("\n");
-          } else if (anchor) {
-            // If an anchor is specified, extract the relevant section from the file
-            // Regular expression for extracting a section of content based on anchors in a file.
-            //
-            // Explanation of the regex pattern:
-            //
-            // `\\s*/{2,} ANCHOR: ${anchor}\\n{1,}` - This part matches the start of the anchored section:
-            //   \\s*        - Matches any whitespace characters (including none) before the anchor comment.
-            //   /{2,}       - Matches two or more forward slashes, accommodating different comment styles.
-            //   ANCHOR:     - Matches the literal string " ANCHOR:" which precedes the anchor name.
-            //   ${anchor}   - Dynamically inserts the anchor name into the regex.
-            //   \\n{1,}     - Matches one or more newline characters, accommodating variations in line breaks.
-            //
-            // `(\\s*[\\s\\S]*?)` - This is the capturing group that matches the content of the anchored section:
-            //   \\s*        - Matches any whitespace characters (including none) at the beginning of the content.
-            //   [\\s\\S]*?  - A non-greedy match for any characters (including newlines). This captures the
-            //                 content until it reaches the end anchor comment.
-            //
-            // `\\n{1,}\\s*/{2,} ANCHOR_END: ${anchor}` - This part matches the end of the anchored section:
-            //   \\n{1,}     - Matches one or more newline characters before the end anchor comment.
-            //   \\s*        - Matches any whitespace characters (including none) before the end anchor comment.
-            //   /{2,}       - Matches two or more forward slashes, similar to the start anchor.
-            //   ANCHOR_END: - Matches the literal string " ANCHOR_END:" which precedes the anchor name.
-            //   ${anchor}   - Dynamically inserts the anchor name, ensuring it matches the corresponding start anchor.
-            //
-            // The "m" flag (multiline) allows '^' and '$' to match the start and end of lines, not just the start
-            // and end of the string. This is important for matching anchors that are not at the very start or end
-            // of the file content.
-            //
-            // This regex is designed to be flexible with line endings and whitespace, accommodating variations in file formatting.
-            const anchorRegex = new RegExp(
-              `\\s*/{2,} ANCHOR: ${anchor}\\n{1,}(\\s*[\\s\\S]*?)\\n{1,}\\s*/{2,} ANCHOR_END: ${anchor}`,
-              "m",
-            );
-            const anchoredContent = fileContent.match(anchorRegex);
-            fileContent = anchoredContent
-              ? anchoredContent[1]
-              : `// Anchor '${anchor}' not found in ${filePath}`;
-          }
-          // Remove lines containing start and end anchor comments
-          fileContent = fileContent
-            .split("\n")
-            .filter((line) => !line.includes("// ANCHOR: ") && !line.includes("// ANCHOR_END: "))
-            .join("\n");
-          // Replace the include directive with the indented file content
-          node.value = node.value.replace(match[0], fileContent);
+          let fullPath = includePath.startsWith("@")
+            ? includePath.replace("@", "./")
+            : path.resolve(path.dirname(markdownFile.path), includePath);
+          let content = include(fullPath, anchor);
+          // Replace the include directive with the file content
+          node.value = node.value.replace(match[0], content);
         } catch (err) {
           if (err instanceof Error) {
-            throw new Error(`Error reading file '${fullPath}': ${err.message}`);
+            throw new Error(`Error including file: ${err.message}`);
+          } else {
+            throw new Error(`Error including file: ${err}`);
           }
         }
       }
@@ -125,3 +65,61 @@ const remarkIncludeCode = () => {
 };
 
 export default remarkIncludeCode;
+
+function include(indludePath: string, anchor?: string): string {
+  try {
+    let fileContent = fs.readFileSync(indludePath, "utf8");
+
+    // if the anchor is in the format "start:end", extract the lines between the start and end
+    if (anchor && anchor.search(":") != -1) {
+      const [start, end] = anchor.split(":");
+      const lines = fileContent.split("\n");
+      const startIndex = start ? parseInt(start) - 1 : 0;
+      const endIndex = end ? parseInt(end) : lines.length;
+      fileContent = lines.slice(startIndex, endIndex).join("\n");
+    } else if (anchor) {
+      // If an anchor is specified, extract the relevant section from the file between
+      // the start and end anchor comments. This is done using a
+      const commentRegex = rx`
+        \s*         // optional whitespace
+        (/{2,}|#)   // two or more forward slashes or a #
+      `;
+      const startAnchorRegex = rx`
+        ${commentRegex} // two or more forward slashes or a #
+        \s*             // optional whitespace
+        ANCHOR:         // the literal string "ANCHOR:" which precedes the anchor name
+        \s*             // optional whitespace characters
+        ${anchor}       // the anchor name
+        \n{1,}          // one or more newline characters, accommodating variations in line breaks
+      `;
+      const endAnchorRegex = rx`
+        \n{1,}          // one or more newline characters before the end anchor comment
+        ${commentRegex} // two or more forward slashes or a #
+        \s*             // optional whitespace
+        ANCHOR_END:     // the literal string "ANCHOR_END:" which precedes the anchor name
+        \s*             // optional whitespace characters
+        ${anchor}       // the anchor name
+      `;
+      // The "m" flag (multiline) allows the regex to match across multiple lines.
+      const anchorRegex = rx.m`   // multiline (matches across multiple lines)
+        ${startAnchorRegex}       // matches the start anchor
+        (?<content>\s*[\s\S]*?)   // a non-greedy match for any characters (including newlines), capturing the content
+        ${endAnchorRegex}         // matches the end anchor
+      `;
+      const anchorContent = fileContent.match(anchorRegex)?.groups?.content;
+      if (!anchorContent) throw new Error(`Anchor '${anchor}' not found in ${indludePath}`);
+      fileContent = anchorContent;
+    }
+    // Remove lines containing start and end anchor comments
+    return fileContent
+      .split("\n")
+      .filter((line) => !line.includes("// ANCHOR: ") && !line.includes("// ANCHOR_END: "))
+      .join("\n");
+  } catch (err) {
+    if (err instanceof Error) {
+      throw new Error(`Error reading file '${indludePath}': ${err.message}`);
+    } else {
+      throw new Error(`Error reading file '${indludePath}': ${err}`);
+    }
+  }
+}


### PR DESCRIPTION
Accept # as comments
Use verbose regex instead of massive comment block
Accept spaces around import statement
Throw an exception if the anchor is missing
