### PR TITLE
Add title back

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -35,7 +35,6 @@ export default defineConfig({
       logo: {
         light: "./src/assets/logo.png",
         dark: "./src/assets/logo-dark.png",
-        replacesTitle: true,
       },
       favicon: "./src/assets/logo.png",
       components: {


### PR DESCRIPTION
The site looks weird without a title on the docs pages.
We need a logo that has a title built-in but for now, a text title works.
