### PR TITLE
Add link badge

### DIFF
--- a/src/components/LinkBadge.astro
+++ b/src/components/LinkBadge.astro
@@ -1,0 +1,88 @@
+---
+// a link badge is a small badge that can be used to link to other pages or resources
+// its style is based on a tweaked copy of the starlight badge component
+interface Props {
+  href?: string;
+  text: string;
+  variant?: "outline" | "default" | "note" | "danger" | "success" | "caution" | "tip";
+}
+const { href, text, variant = "default" } = Astro.props;
+---
+
+<a href={href} class:list={["link-badge", "default"]} set:html={text} />
+
+<style>
+  .link-badge {
+    display: inline-block;
+    text-decoration: none;
+    border: 1px solid var(--sl-color-border-badge);
+    border-radius: 0.5rem;
+    font-family: var(--sl-font-system-mono);
+    font-weight: 400;
+    padding: 0.25rem 0.375rem;
+    line-height: 1;
+    color: #fff;
+    background-color: var(--sl-color-bg-badge);
+    overflow-wrap: anywhere;
+  }
+
+  .outline {
+    --sl-color-bg-badge: transparent;
+    --sl-color-border-badge: currentColor;
+    color: inherit;
+  }
+
+  .default {
+    --sl-color-bg-badge: var(--sl-color-accent-low);
+    --sl-color-border-badge: var(--sl-color-accent);
+  }
+
+  .note {
+    --sl-color-bg-badge: var(--sl-color-blue-low);
+    --sl-color-border-badge: var(--sl-color-blue);
+  }
+
+  .danger {
+    --sl-color-bg-badge: var(--sl-color-red-low);
+    --sl-color-border-badge: var(--sl-color-red);
+  }
+
+  .success {
+    --sl-color-bg-badge: var(--sl-color-green-low);
+    --sl-color-border-badge: var(--sl-color-green);
+  }
+
+  .caution {
+    --sl-color-bg-badge: var(--sl-color-orange-low);
+    --sl-color-border-badge: var(--sl-color-orange);
+  }
+
+  .tip {
+    --sl-color-bg-badge: var(--sl-color-purple-low);
+    --sl-color-border-badge: var(--sl-color-purple);
+  }
+
+  :global([data-theme="light"]) .default {
+    --sl-color-bg-badge: var(--sl-color-accent-high);
+  }
+
+  :global([data-theme="light"]) .note {
+    --sl-color-bg-badge: var(--sl-color-blue-high);
+  }
+
+  :global([data-theme="light"]) .danger {
+    --sl-color-bg-badge: var(--sl-color-red-high);
+  }
+
+  :global([data-theme="light"]) .success {
+    --sl-color-bg-badge: var(--sl-color-green-high);
+  }
+
+  :global([data-theme="light"]) .caution {
+    --sl-color-bg-badge: var(--sl-color-orange-high);
+  }
+
+  :global([data-theme="light"]) .tip {
+    --sl-color-bg-badge: var(--sl-color-purple-high);
+  }
+</style>


### PR DESCRIPTION
Makes it easy to add badges in mdx files. E.g.:

<img width="744" alt="image" src="https://github.com/ratatui-org/website/assets/381361/2518c99a-1fa4-4f47-85fb-fef902eb90cc">
