### PR TITLE
Split built-in and third party widget pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -256,7 +256,8 @@ export default defineConfig({
           label: "Showcase", collapsed: true, items: [
             { label: "Showcase", link: "/showcase/" },
             { label: "Apps", link: "/showcase/apps/" },
-            { label: "Widgets", link: "/showcase/widgets/" },
+            { label: "Built-in Widgets", link: "/showcase/widgets/" },
+            { label: "Third Party Widgets", link: "/showcase/third-party-widgets/" },
           ],
         },
         { label: "References", link: "/references/" },

--- a/src/content/docs/showcase/third-party-widgets/index.mdx
+++ b/src/content/docs/showcase/third-party-widgets/index.mdx
@@ -1,0 +1,58 @@
+---
+title: Third Party Widgets Showcase
+---
+
+import LinkBadge from '/src/components/LinkBadge.astro';
+
+To add your widgets to this list, please read the [Third Party Widgets
+README](https://github.com/ratatui-org/website/tree/main/code/widget-showcase-third-party/README.md)
+
+## Throbber-widgets-tui <LinkBadge text="Crate" href="https://crates.io/crates/throbber-widgets-tui" /> <LinkBadge text="Docs" href="https://docs.rs/throbber-widgets-tui" /> <LinkBadge text="GitHub" href="https://github.com/arkbig/throbber-widgets-tui" />
+
+[`throbber-widgets-tui`](https://crates.io/crates/throbber-widgets-tui) is a widget that displays throbber. Also-known-as an activity indicator,
+progress bar, loading icon, spinner, or ぐるぐる (guru guru).
+
+![throbber-widgets-tui](./throbber-widgets-tui.gif)
+
+## Tui-big-text <LinkBadge text="Crate" href="https://crates.io/crates/tui-big-text" /> <LinkBadge text="Docs" href="https://docs.rs/tui-big-text" /> <LinkBadge text="GitHub" href="https://github.com/joshka/tui-big-text" />
+
+[`tui-big-text`](https://crates.io/crates/tui-big-text) is a rust crate that renders large pixel text
+as a widget using the glyphs from the [font8x8](https://crates.io/crates/font8x8) crate.
+
+![tui-big-text](./tui-big-text.png)
+
+## Tui-nodes <LinkBadge text="Crate" href="https://crates.io/crates/tui-nodes" /> <LinkBadge text="Docs" href="https://docs.rs/tui-nodes" /> <LinkBadge text="Sourcehut" href="https://git.sr.ht/~jaxter184/tui-nodes" />
+
+[`tui-nodes`](https://crates.io/crates/tui-nodes) is aNode graph visualization widget.
+
+![tui-nodes](./tui-nodes.gif)
+
+## Tui-term <LinkBadge text="Crate" href="https://crates.io/crates/tui-term" /> <LinkBadge text="Docs" href="https://docs.rs/tui-term" /> <LinkBadge text="GitHub" href="https://github.com/a-kenji/tui-term" />
+
+[`tui-term`t](https://crates.io/crates/tui-term) is a pseudoterminal widget.
+
+![Demo of tui-term](https://vhs.charm.sh/vhs-4zK1zlTOSueAmlOkZlssBr.gif)
+
+## Tui-textarea <LinkBadge text="Crate" href="https://crates.io/crates/tui-textarea" /> <LinkBadge text="Docs" href="https://docs.rs/tui-textarea" /> <LinkBadge text="GitHub" href="https://github.com/rhysd/tui-textarea" />
+
+[`tui-textarea`](https://crates.io/crates/tui-textarea) is a simple yet powerful text editor widget
+like `<textarea>` in HTML for ratatui and tui-rs. Multi-line text editor can be easily put as part
+of your TUI application.
+
+![tui-textarea](./tui-textarea.gif)
+
+## Tui-tree-widget <LinkBadge text="Crate" href="https://crates.io/crates/tui-tree-widget" /> <LinkBadge text="Docs" href="https://docs.rs/tui-tree-widget" /> <LinkBadge text="GitHub" href="https://github.com/EdJoPaTo/tui-rs-tree-widget" />
+
+[`tui-tree-widget`](https://crates.io/crates/tui-tree-widget) is a widget built to show Tree Data
+structures.
+
+![tui-tree-widget](./tui-treeview.gif)
+
+
+## Tui-widget-list <LinkBadge text="Crate" href="https://crates.io/crates/tui-widget-list" /> <LinkBadge text="Docs" href="https://docs.rs/tui-widget-list" /> <LinkBadge text="GitHub" href="https://github.com/preiter93/tui-widget-list" />
+
+[`tui-widget-list`](https://crates.io/crates/tui-widget-list) is stateful widget list implementation
+`List` for Ratatui that allows to work with any list of widgets that implement to the `Listable`
+trait. 
+
+![tui-widget-list](./tui-widget-list.gif)

--- a/src/content/docs/showcase/third-party-widgets/throbber-widgets-tui.gif
+++ b/src/content/docs/showcase/third-party-widgets/throbber-widgets-tui.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:196b64bd16ae3b5e12ebab6f96ed09829bbbaeaf86bdf13453e8a8b34f214ab0
+size 120996

--- a/src/content/docs/showcase/third-party-widgets/tui-big-text.png
+++ b/src/content/docs/showcase/third-party-widgets/tui-big-text.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9fa75eba660acfd09435e74e9491cbc85dab3dc54ba7468f220c63d9d29cde6d
+size 20597

--- a/src/content/docs/showcase/third-party-widgets/tui-nodes.gif
+++ b/src/content/docs/showcase/third-party-widgets/tui-nodes.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da83aacb210376791fe4f737f0e4c99fd256d8595be0b1e469895b5b737119c9
+size 19480

--- a/src/content/docs/showcase/third-party-widgets/tui-term.gif
+++ b/src/content/docs/showcase/third-party-widgets/tui-term.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0b0b20f398f945f1691d8e0d289e9f745982129c2e6c76128bb87eaf80df6866
+size 2298842

--- a/src/content/docs/showcase/third-party-widgets/tui-textarea.gif
+++ b/src/content/docs/showcase/third-party-widgets/tui-textarea.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:37d4cc437d165f9fdf251d960a9e65a98caa27da4242185ebfe64b573a40f6ef
+size 1633142

--- a/src/content/docs/showcase/third-party-widgets/tui-treeview.gif
+++ b/src/content/docs/showcase/third-party-widgets/tui-treeview.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:411635b09eb0e66421b0983bf45b2e9a21945a3ae06730952ac4ccadda26fb17
+size 113580

--- a/src/content/docs/showcase/third-party-widgets/tui-widget-list.gif
+++ b/src/content/docs/showcase/third-party-widgets/tui-widget-list.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e8a229fa1f821c6ff209c80dfaa9034d25bf33868387257404ba50649b5b97fd
+size 220369

--- a/src/content/docs/showcase/widgets/index.mdx
+++ b/src/content/docs/showcase/widgets/index.mdx
@@ -1,10 +1,8 @@
 ---
-title: Widgets Showcase
+title: Built-in Widgets Showcase
 ---
 
 import LinkBadge from '/src/components/LinkBadge.astro';
-
-## Built-in Widgets <LinkBadge href="https://github.com/ratatui-org/website/issues/249" text="Help Wanted" variant="caution" />
 
 The following widgets are built-in and available in the `ratatui` crate. They are all documented in
 the [API docs](https://docs.rs/ratatui/latest/ratatui/widgets/index.html).
@@ -15,91 +13,40 @@ https://github.com/ratatui-org/website/issues/249 for information about how to c
 [widget-showcase]: https://github.com/ratatui-org/website/blob/main/code/widget-showcase
 [VHS]: https://github.com/charmbracelet/vhs
 
-### Block <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/block/struct.Block.html" text="Docs" />
+## Block <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/block/struct.Block.html" text="Docs" />
 
 ![Block](./block.png)
 
-### BarChart <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.BarChart.html" text="Docs" />
+## BarChart <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.BarChart.html" text="Docs" />
 
 ![BarChart](./bar_chart.png)
 
-### Calendar <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/calendar/struct.Calendar.html" text="Docs" />
+## Calendar <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/calendar/struct.Calendar.html" text="Docs" />
 
 ![Calendar](./calendar.png)
 
-### Canvas <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/canvas/struct.Canvas.html" text="Docs" />
+## Canvas <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/canvas/struct.Canvas.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
 
-### Chart <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Chart.html" text="Docs" />
+## Chart <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Chart.html" text="Docs" />
 
 ![BarChart](./chart.png)
 
-### Gauge <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Gauge.html" text="Docs" />
+## Gauge <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Gauge.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
 
-### LineGauge <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.LineGauge.html" text="Docs" />
+## LineGauge <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.LineGauge.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
 
-### List <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.List.html" text="Docs" />
+## List <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.List.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
 
-### Paragraph <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Paragraph.html" text="Docs" />
+## Paragraph <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Paragraph.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
 
-### Scrollbar <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Scrollbar.html" text="Docs" />
+## Scrollbar <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Scrollbar.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
 
-### Sparkline <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Sparkline.html" text="Docs" />
+## Sparkline <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Sparkline.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
 
-### Table <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Table.html" text="Docs" />
+## Table <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Table.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
 
-### Tabs <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Tabs.html" text="Docs" />
+## Tabs <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Tabs.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
 
 ## Third Party Widgets
 
-To add your widgets to this list, please read the [Third Party Widgets
-README](https://github.com/ratatui-org/website/tree/main/code/widget-showcase-third-party/README.md)
-
-### Throbber-widgets-tui <LinkBadge text="Crate" href="https://crates.io/crates/throbber-widgets-tui" /> <LinkBadge text="Docs" href="https://docs.rs/throbber-widgets-tui" /> <LinkBadge text="GitHub" href="https://github.com/arkbig/throbber-widgets-tui" />
-
-[`throbber-widgets-tui`](https://crates.io/crates/throbber-widgets-tui) is a widget that displays throbber. Also-known-as an activity indicator,
-progress bar, loading icon, spinner, or ぐるぐる (guru guru).
-
-![throbber-widgets-tui](./throbber-widgets-tui.gif)
-
-### Tui-big-text <LinkBadge text="Crate" href="https://crates.io/crates/tui-big-text" /> <LinkBadge text="Docs" href="https://docs.rs/tui-big-text" /> <LinkBadge text="GitHub" href="https://github.com/joshka/tui-big-text" />
-
-[`tui-big-text`](https://crates.io/crates/tui-big-text) is a rust crate that renders large pixel text
-as a widget using the glyphs from the [font8x8](https://crates.io/crates/font8x8) crate.
-
-![tui-big-text](./tui-big-text.png)
-
-### Tui-nodes <LinkBadge text="Crate" href="https://crates.io/crates/tui-nodes" /> <LinkBadge text="Docs" href="https://docs.rs/tui-nodes" /> <LinkBadge text="Sourcehut" href="https://git.sr.ht/~jaxter184/tui-nodes" />
-
-[`tui-nodes`](https://crates.io/crates/tui-nodes) is aNode graph visualization widget.
-
-![tui-nodes](./tui-nodes.gif)
-
-### Tui-term <LinkBadge text="Crate" href="https://crates.io/crates/tui-term" /> <LinkBadge text="Docs" href="https://docs.rs/tui-term" /> <LinkBadge text="GitHub" href="https://github.com/a-kenji/tui-term" />
-
-[`tui-term`t](https://crates.io/crates/tui-term) is a pseudoterminal widget.
-
-![Demo of tui-term](https://vhs.charm.sh/vhs-4zK1zlTOSueAmlOkZlssBr.gif)
-
-### Tui-textarea <LinkBadge text="Crate" href="https://crates.io/crates/tui-textarea" /> <LinkBadge text="Docs" href="https://docs.rs/tui-textarea" /> <LinkBadge text="GitHub" href="https://github.com/rhysd/tui-textarea" />
-
-[`tui-textarea`](https://crates.io/crates/tui-textarea) is a simple yet powerful text editor widget
-like `<textarea>` in HTML for ratatui and tui-rs. Multi-line text editor can be easily put as part
-of your TUI application.
-
-![tui-textarea](./tui-textarea.gif)
-
-### Tui-tree-widget <LinkBadge text="Crate" href="https://crates.io/crates/tui-tree-widget" /> <LinkBadge text="Docs" href="https://docs.rs/tui-tree-widget" /> <LinkBadge text="GitHub" href="https://github.com/EdJoPaTo/tui-rs-tree-widget" />
-
-[`tui-tree-widget`](https://crates.io/crates/tui-tree-widget) is a widget built to show Tree Data
-structures.
-
-![tui-tree-widget](./tui-treeview.gif)
-
-
-### Tui-widget-list <LinkBadge text="Crate" href="https://crates.io/crates/tui-widget-list" /> <LinkBadge text="Docs" href="https://docs.rs/tui-widget-list" /> <LinkBadge text="GitHub" href="https://github.com/preiter93/tui-widget-list" />
-
-[`tui-widget-list`](https://crates.io/crates/tui-widget-list) is stateful widget list implementation
-`List` for Ratatui that allows to work with any list of widgets that implement to the `Listable`
-trait. 
-
-![tui-widget-list](./tui-widget-list.gif)
+See the next page for a showcase of [third party widgets](../third-party-widgets).


### PR DESCRIPTION
- Add tui-term to widget showcase
- Add tui-nodes to widget showcase
- Split built-in and third party widget pages
