### PR TITLE
Fix LinkBadge contrast

### DIFF
--- a/src/components/LinkBadge.astro
+++ b/src/components/LinkBadge.astro
@@ -15,74 +15,50 @@ const { href, text, variant = "default" } = Astro.props;
   .link-badge {
     display: inline-block;
     text-decoration: none;
-    border: 1px solid var(--sl-color-border-badge);
+    border: 1px solid var(--rat-color-border-badge);
     border-radius: 0.5rem;
     font-family: var(--sl-font-system-mono);
     font-weight: 400;
     padding: 0.25rem 0.375rem;
     line-height: 1;
     color: #fff;
-    background-color: var(--sl-color-bg-badge);
+    background-color: var(--rat-color-bg-badge);
     overflow-wrap: anywhere;
   }
 
   .outline {
     --sl-color-bg-badge: transparent;
-    --sl-color-border-badge: currentColor;
+    --rat-color-border-badge: currentColor;
     color: inherit;
   }
 
   .default {
-    --sl-color-bg-badge: var(--sl-color-accent-low);
-    --sl-color-border-badge: var(--sl-color-accent);
+    --rat-color-bg-badge: var(--sl-color-accent-low);
+    --rat-color-border-badge: var(--sl-color-accent);
   }
 
   .note {
-    --sl-color-bg-badge: var(--sl-color-blue-low);
-    --sl-color-border-badge: var(--sl-color-blue);
+    --rat-color-bg-badge: var(--sl-color-blue-low);
+    --rat-color-border-badge: var(--sl-color-blue);
   }
 
   .danger {
-    --sl-color-bg-badge: var(--sl-color-red-low);
-    --sl-color-border-badge: var(--sl-color-red);
+    --rat-color-bg-badge: var(--sl-color-red-low);
+    --rat-color-border-badge: var(--sl-color-red);
   }
 
   .success {
-    --sl-color-bg-badge: var(--sl-color-green-low);
-    --sl-color-border-badge: var(--sl-color-green);
+    --rat-color-bg-badge: var(--sl-color-green-low);
+    --rat-color-border-badge: var(--sl-color-green);
   }
 
   .caution {
-    --sl-color-bg-badge: var(--sl-color-orange-low);
-    --sl-color-border-badge: var(--sl-color-orange);
+    --rat-color-bg-badge: var(--sl-color-orange-low);
+    --rat-color-border-badge: var(--sl-color-orange);
   }
 
   .tip {
-    --sl-color-bg-badge: var(--sl-color-purple-low);
-    --sl-color-border-badge: var(--sl-color-purple);
-  }
-
-  :global([data-theme="light"]) .default {
-    --sl-color-bg-badge: var(--sl-color-accent-high);
-  }
-
-  :global([data-theme="light"]) .note {
-    --sl-color-bg-badge: var(--sl-color-blue-high);
-  }
-
-  :global([data-theme="light"]) .danger {
-    --sl-color-bg-badge: var(--sl-color-red-high);
-  }
-
-  :global([data-theme="light"]) .success {
-    --sl-color-bg-badge: var(--sl-color-green-high);
-  }
-
-  :global([data-theme="light"]) .caution {
-    --sl-color-bg-badge: var(--sl-color-orange-high);
-  }
-
-  :global([data-theme="light"]) .tip {
-    --sl-color-bg-badge: var(--sl-color-purple-high);
+    --rat-color-bg-badge: var(--sl-color-purple-low);
+    --rat-color-border-badge: var(--sl-color-purple);
   }
 </style>

--- a/src/content/docs/developer-guide/website.mdx
+++ b/src/content/docs/developer-guide/website.mdx
@@ -25,3 +25,16 @@ Feel free to make contributions and submit a PR if you'd like to improve the doc
 - Prefer links from the root rather than using mulitple levels of parent links. (e.g.
   `/concepts/backends/comparison/` instead of `../../backends/comparison/`).
 - Prefer to add the last slash on links
+
+## Custom components
+
+### LinkBadge
+import LinkBadge from '/src/components/LinkBadge.astro';
+
+        <LinkBadge text="default" href="" variant="default" />
+        <LinkBadge text="outline" href="" variant="outline" />
+        <LinkBadge text="note" href="" variant="note" />
+        <LinkBadge text="danger" href="" variant="danger" />
+        <LinkBadge text="success" href="" variant="success" />
+        <LinkBadge text="caution" href="" variant="caution" />
+        <LinkBadge text="tip" href="" variant="tip" />


### PR DESCRIPTION
Fixes https://github.com/ratatui-org/website/issues/267

Adds a sample of the LinkBadge to https://fix-linkbadge-contrast.ratatui.pages.dev/developer-guide/website/#linkbadge

<img width="533" alt="image" src="https://github.com/ratatui-org/website/assets/381361/e0a974c4-e21b-4390-8275-d118219daef9">

<img width="588" alt="image" src="https://github.com/ratatui-org/website/assets/381361/88650d0b-7161-45f8-a860-3465fe66aaa9">
