### PR TITLE
chore(docs): fix typo in `showcase/third-party-widgets`

### DIFF
--- a/src/content/docs/showcase/third-party-widgets/index.mdx
+++ b/src/content/docs/showcase/third-party-widgets/index.mdx
@@ -29,7 +29,7 @@ as a widget using the glyphs from the [font8x8](https://crates.io/crates/font8x8
 
 ## Tui-term <LinkBadge text="Crate" href="https://crates.io/crates/tui-term" /> <LinkBadge text="Docs" href="https://docs.rs/tui-term" /> <LinkBadge text="GitHub" href="https://github.com/a-kenji/tui-term" />
 
-[`tui-term`t](https://crates.io/crates/tui-term) is a pseudoterminal widget.
+[`tui-term`](https://crates.io/crates/tui-term) is a pseudoterminal widget.
 
 ![Demo of tui-term](https://vhs.charm.sh/vhs-4zK1zlTOSueAmlOkZlssBr.gif)
 


### PR DESCRIPTION
Just removed `t`.