### PR TITLE
chore(docs): fix broken link to `showcase/apps`

### DIFF
--- a/src/content/docs/showcase/index.mdx
+++ b/src/content/docs/showcase/index.mdx
@@ -6,7 +6,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     {/* I have no idea why vscode chose this mangled formatting */}
 
     <CardGrid>
-                <Card title="<a href='./apps'>Apps</a>" icon="rocket">
+                <Card title="<a href='./apps/'>Apps</a>" icon="rocket">
                             <p>Apps built with Ratatui</p>
                             </Card>
   <Card title="<a href='./widgets/'>Widgets</a>" icon="puzzle">

--- a/src/content/docs/showcase/index.mdx
+++ b/src/content/docs/showcase/index.mdx
@@ -6,7 +6,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
     {/* I have no idea why vscode chose this mangled formatting */}
 
     <CardGrid>
-                <Card title="<a href='./apps.md'>Apps</a>" icon="rocket">
+                <Card title="<a href='./apps'>Apps</a>" icon="rocket">
                             <p>Apps built with Ratatui</p>
                             </Card>
   <Card title="<a href='./widgets/'>Widgets</a>" icon="puzzle">


### PR DESCRIPTION
[In this page](https://ratatui.rs/showcase/), when the element within red rectangle is clicked, browser shows 404 page.

<img width="1493" alt="image" src="https://github.com/ratatui-org/website/assets/49891479/ce7abd16-6706-46e2-b7c4-bd7a77941f1d">

I tested that the link works fine by 0fbe8088d539bfca58847725812602cef6359f94 in my local environment following the instruction in README.