### PR TITLE
Make the link badge a little bit smaller

### DIFF
--- a/src/components/LinkBadge.astro
+++ b/src/components/LinkBadge.astro
@@ -19,6 +19,7 @@ const { href, text, variant = "default" } = Astro.props;
     border-radius: 0.5rem;
     font-family: var(--sl-font-system-mono);
     font-weight: 400;
+    font-size: 0.75em;
     padding: 0.25rem 0.375rem;
     line-height: 1;
     color: #fff;


### PR DESCRIPTION
Fits better on the third party widgets page

<img width="712" alt="image" src="https://github.com/ratatui-org/website/assets/381361/58db1cad-ef34-4967-8340-bce098e6683d">

<img width="711" alt="image" src="https://github.com/ratatui-org/website/assets/381361/98b641a4-ffda-4fd8-8fe5-d4cc959cab86">
