### PR TITLE
feat(rendering): link to templates

### DIFF
--- a/src/content/docs/concepts/rendering/index.md
+++ b/src/content/docs/concepts/rendering/index.md
@@ -69,4 +69,8 @@ This 4 minute talk about `IMGUI` is also tangentially relevant.
 
 - **Architecture design considerations**: With `ratatui`, out of the box, there's little to no help
   in organizing large applications. Ultimately, the decision on structure and discipline rests with
-  the developer to be principled.
+  the developer to be principled. However, we do provide a [template] and an [async template] to
+  help you get started.
+
+[template]: https://github.com/ratatui-org/ratatui-template
+[async template]: https://github.com/ratatui-org/ratatui-async-template


### PR DESCRIPTION
I just feel like we should link them to say "this is a downside but we provide a workaround/help"