### PR TITLE
chore: cargo ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: Continuous Integration
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+
+# ensure that the workflow is only triggered once per PR,  subsequent pushes to the PR will cancel
+# and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+# lint, clippy and coverage jobs are intentionally early in the workflow to catch simple
+# formatting, typos, and missing tests as early as possible. This allows us to fix these and
+# resubmit the PR without having to wait for the comprehensive matrix of tests to complete.
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v4
+      - name: Checkout
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check typos
+        uses: crate-ci/typos@master
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,22 +17,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
-# lint, clippy and coverage jobs are intentionally early in the workflow to catch simple
-# formatting, typos, and missing tests as early as possible. This allows us to fix these and
-# resubmit the PR without having to wait for the comprehensive matrix of tests to complete.
 jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        if: github.event_name != 'pull_request'
         uses: actions/checkout@v4
-      - name: Checkout
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Install Rust nightly
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -44,6 +34,8 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Check typos
         uses: crate-ci/typos@master
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,18 @@
 # See https://doc.rust-lang.org/cargo/reference/workspaces.html
 [workspace]
-members = ["code/*"]
+members = [
+  "code/hello-world-tutorial",
+  "code/how-to-collapse-borders",
+  "code/how-to-color_eyre",
+  "code/how-to-overwrite-regions",
+  "code/quickstart-ratatui",
+  "code/ratatui-counter-app",
+  "code/ratatui-counter-async-app",
+  "code/ratatui-json-editor-app",
+  "code/ratatui-stopwatch-app",
+  "code/the-elm-architecture",
+  "code/widget-showcase",
+]
 resolver = "2"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,9 @@
 # See https://doc.rust-lang.org/cargo/reference/workspaces.html
 [workspace]
-members = [
+members = ["code/*"]
+exclude = [
+  "code/widget-showcase-third-party" # only contains VHS tape files
+] 
   "code/hello-world-tutorial",
   "code/how-to-collapse-borders",
   "code/how-to-color_eyre",

--- a/code/how-to-collapse-borders/src/bin/problem.rs
+++ b/code/how-to-collapse-borders/src/bin/problem.rs
@@ -19,7 +19,6 @@ struct Term {
 }
 
 fn main() -> Result<()> {
-
     let mut term = Term::init()?;
     loop {
         term.terminal.draw(ui)?;

--- a/code/how-to-collapse-borders/src/bin/solution.rs
+++ b/code/how-to-collapse-borders/src/bin/solution.rs
@@ -23,7 +23,6 @@ struct Term {
 /// This example shows how to use custom borders to collapse borders between widgets.
 /// See https://ratatui.rs/how-to/layout/collapse-borders for more info
 fn main() -> Result<()> {
-
     let mut term = Term::init()?;
     loop {
         term.terminal.draw(ui)?;

--- a/code/how-to-overwrite-regions/src/bin/solution.rs
+++ b/code/how-to-overwrite-regions/src/bin/solution.rs
@@ -91,7 +91,7 @@ fn ui(frame: &mut Frame) {
 }
 // ANCHOR_END: ui
 
-fn key_pressed() ->  color_eyre::Result<bool> {
+fn key_pressed() -> color_eyre::Result<bool> {
     Ok(event::poll(Duration::from_millis(16))?
         && matches!(event::read()?, Event::Key(_)))
 }

--- a/code/the-elm-architecture/src/main.rs
+++ b/code/the-elm-architecture/src/main.rs
@@ -43,7 +43,7 @@ fn main() -> color_eyre::Result<()> {
         let mut current_msg = handle_event(&model)?;
 
         // Process updates as long as they return a non-None message
-        while current_msg != None {
+        while current_msg.is_some() {
             current_msg = update(&mut model, current_msg.unwrap());
         }
     }

--- a/code/widget-showcase/src/examples/calendar.rs
+++ b/code/widget-showcase/src/examples/calendar.rs
@@ -1,7 +1,4 @@
-use ratatui::{
-    prelude::*,
-    widgets::{calendar::*, *},
-};
+use ratatui::{prelude::*, widgets::calendar::*};
 use time::{Date, Month};
 
 pub fn render(frame: &mut Frame) -> color_eyre::Result<()> {

--- a/code/widget-showcase/src/main.rs
+++ b/code/widget-showcase/src/main.rs
@@ -104,18 +104,18 @@ impl App {
         if !event::poll(Duration::from_secs(3))? {
             self.running_state = RunningState::Finished;
         }
-        match event::read()? {
-            Event::Key(KeyEvent {
-                code,
-                kind: KeyEventKind::Press,
-                ..
-            }) => match code {
+        if let Event::Key(KeyEvent {
+            code,
+            kind: KeyEventKind::Press,
+            ..
+        }) = event::read()?
+        {
+            match code {
                 KeyCode::Char('q') | KeyCode::Char('Q') => {
                     self.running_state = RunningState::Finished;
                 }
                 _ => {}
-            },
-            _ => {}
+            }
         }
         Ok(())
     }

--- a/src/content/docs/developer-guide/website.mdx
+++ b/src/content/docs/developer-guide/website.mdx
@@ -22,7 +22,7 @@ Feel free to make contributions and submit a PR if you'd like to improve the doc
 
 ## Some Guidelines
 
-- Prefer links from the root rather than using mulitple levels of parent links. (e.g.
+- Prefer links from the root rather than using multiple levels of parent links. (e.g.
   `/concepts/backends/comparison/` instead of `../../backends/comparison/`).
 - Prefer to add the last slash on links
 

--- a/typos.toml
+++ b/typos.toml
@@ -1,0 +1,9 @@
+# configuration for https://github.com/crate-ci/typos
+
+[default.extend-words]
+ratatui = "ratatui"
+
+[type.md]
+extend-ignore-re = [
+  "\\[[[:xdigit:]]{7}\\]\\(https://github.com/ratatui-org/ratatui/commit/[[:xdigit:]]{40}\\)",
+]


### PR DESCRIPTION
I added a workflow for cargo projects. I kept it simple for now.

I also fixed the various lints, typos and fmt issues already present.

The workflow checks:

- Correct formatting (with rust stable, so not the same as ratatui)
- typos
- Clippy lints

I also specified explicitly workspace members because `code/widget-showcase-third-party` is not a cargo project.

Fixes #230 and #231