### PR TITLE
chore: exclude dist

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,6 @@
       "@assets/*": ["src/assets/*"],
       "@code/*": ["src/code/*"]
     }
-  }
+  },
+  "exclude": ["dist"]
 }


### PR DESCRIPTION
Excludes the dist directory so `astro check` doesn't lint it.
See https://github.com/withastro/language-tools/issues/721#issuecomment-1850051563