### PR TITLE
Remove version requirement message from tape files

### DIFF
--- a/code/hello-world-tutorial/hello.tape
+++ b/code/hello-world-tutorial/hello.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source, for the screenshot command and theme
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output hello.gif
 Set Theme "Aardvark Blue"
 Set Width 800
@@ -7,7 +6,6 @@ Set Height 450
 Type "cargo run"
 Enter
 Sleep 7s
-# requires vhs installed from source until the next version drops
 Screenshot hello.png
 Sleep 1s
 Type q

--- a/code/how-to-collapse-borders/problem.tape
+++ b/code/how-to-collapse-borders/problem.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source, for the screenshot command and theme
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output collapse-borders-problem.gif
 Set Theme "Aardvark Blue"
 Set Width 800
@@ -7,7 +6,6 @@ Set Height 450
 Type "cargo run --bin problem"
 Enter
 Sleep 2s
-# requires vhs installed from source until the next version drops
 Screenshot collapse-borders-problem.png
 Sleep 1s
 Type q

--- a/code/how-to-collapse-borders/solution.tape
+++ b/code/how-to-collapse-borders/solution.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source, for the screenshot command and theme
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output collapse-borders-solution.gif
 Set Theme "Aardvark Blue"
 Set Width 800
@@ -7,7 +6,6 @@ Set Height 450
 Type "cargo run --bin solution"
 Enter
 Sleep 2s
-# requires vhs installed from source until the next version drops
 Screenshot collapse-borders-solution.png
 Sleep 1s
 Type q

--- a/code/how-to-color_eyre/demo.tape
+++ b/code/how-to-color_eyre/demo.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/how-to/develop-apps/color-eyre/demo.gif"
 Set Theme "Aardvark Blue"
 Set Width 1200

--- a/code/how-to-color_eyre/error-full.tape
+++ b/code/how-to-color_eyre/error-full.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/how-to/develop-apps/color-eyre/error-full.gif"
 Set Theme "Aardvark Blue"
 Set Width 1280

--- a/code/how-to-color_eyre/error.tape
+++ b/code/how-to-color_eyre/error.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/how-to/develop-apps/color-eyre/error.gif"
 Set Theme "Aardvark Blue"
 Set Width 1280

--- a/code/how-to-color_eyre/panic-full.tape
+++ b/code/how-to-color_eyre/panic-full.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/how-to/develop-apps/color-eyre/panic-full.gif"
 Set Theme "Aardvark Blue"
 Set Width 1280

--- a/code/how-to-color_eyre/panic.tape
+++ b/code/how-to-color_eyre/panic.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/how-to/develop-apps/color-eyre/panic.gif"
 Set Theme "Aardvark Blue"
 Set Width 1280

--- a/code/how-to-color_eyre/quit.tape
+++ b/code/how-to-color_eyre/quit.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/how-to/develop-apps/color-eyre/quit.gif"
 Set Theme "Aardvark Blue"
 Set Width 1280

--- a/code/how-to-overwrite-regions/problem.tape
+++ b/code/how-to-overwrite-regions/problem.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source, for the screenshot command and theme
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output overwrite-regions-problem.gif
 Set Theme "Aardvark Blue"
 Set Width 800
@@ -9,7 +8,6 @@ Type "cargo run --bin problem"
 Enter
 Sleep 2s
 Show
-# requires vhs installed from source until the next version drops
 Screenshot overwrite-regions-problem.png
 Sleep 1s
 Hide

--- a/code/how-to-overwrite-regions/solution.tape
+++ b/code/how-to-overwrite-regions/solution.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source, for the screenshot command and theme
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output overwrite-regions-solution.gif
 Set Theme "Aardvark Blue"
 Set Width 800
@@ -9,7 +8,6 @@ Type "cargo run --bin solution"
 Enter
 Sleep 2s
 Show
-# requires vhs installed from source until the next version drops
 Screenshot overwrite-regions-solution.png
 Sleep 1s
 Hide

--- a/code/ratatui-json-editor-app/demo.tape
+++ b/code/ratatui-json-editor-app/demo.tape
@@ -1,3 +1,4 @@
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output demo.gif
 Set Width 1600
 Set Height 900

--- a/code/widget-showcase-third-party/throbber-widgets-tui.tape
+++ b/code/widget-showcase-third-party/throbber-widgets-tui.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 
 # for running against the throbber-widgets-tui git repo https://github.com/arkbig/throbber-widgets-tui
 Output "throbber-widgets-tui.gif"

--- a/code/widget-showcase-third-party/tui-nodes.tape
+++ b/code/widget-showcase-third-party/tui-nodes.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 
 # for running against the tui-tree-widget git repo https://git.sr.ht/~jaxter184/tui-nodes
 Output "tui-nodes.gif"

--- a/code/widget-showcase-third-party/tui-textarea.tape
+++ b/code/widget-showcase-third-party/tui-textarea.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 
 # for running against the tui-textarea git repo https://github.com/rhysd/tui-textarea
 Output "tui-textarea.gif"

--- a/code/widget-showcase-third-party/tui-tree-widget.tape
+++ b/code/widget-showcase-third-party/tui-tree-widget.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 
 # for running against the tui-tree-widget git repo https://github.com/EdJoPaTo/tui-rs-tree-widget
 Output "tui-tree-widget.gif"

--- a/code/widget-showcase-third-party/tui-widget-list.tape
+++ b/code/widget-showcase-third-party/tui-widget-list.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 
 # for running against the tui-tree-widget git repo https://github.com/EdJoPaTo/tui-rs-tree-widget
 Output "tui-widget-list.gif"

--- a/code/widget-showcase/bar_chart.tape
+++ b/code/widget-showcase/bar_chart.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/showcase/widgets/bar_chart.gif"
 Set Theme "Aardvark Blue"
 Set Width 800

--- a/code/widget-showcase/block.tape
+++ b/code/widget-showcase/block.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/showcase/widgets/block.gif"
 Set Theme "Aardvark Blue"
 Set Width 800

--- a/code/widget-showcase/calendar.tape
+++ b/code/widget-showcase/calendar.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/showcase/widgets/calendar.gif"
 Set Theme "Aardvark Blue"
 Set Width 800

--- a/code/widget-showcase/chart.tape
+++ b/code/widget-showcase/chart.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/showcase/widgets/chart.gif"
 Set Theme "Aardvark Blue"
 Set Width 800

--- a/code/widget-showcase/gauge.tape
+++ b/code/widget-showcase/gauge.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/showcase/widgets/gauge.gif"
 Set Theme "Aardvark Blue"
 Set Width 800

--- a/code/widget-showcase/line_gauge.tape
+++ b/code/widget-showcase/line_gauge.tape
@@ -1,5 +1,4 @@
-# This requires vhs installed from source for the updated theme and screenshot command
-# go install github.com/charmbracelet/vhs@main
+# A VHS tape. See https://github.com/charmbracelet/vhs
 Output "../../src/content/docs/showcase/widgets/line_gauge.gif"
 Set Theme "Aardvark Blue"
 Set Width 800


### PR DESCRIPTION
The current version (0.7.1) is now released, so we don't need to install
from git anymore.
