### PR TITLE
docs(rendering): remove '.' in sentence

### DIFF
--- a/src/content/docs/concepts/rendering/index.md
+++ b/src/content/docs/concepts/rendering/index.md
@@ -4,7 +4,7 @@ title: Rendering
 
 The world of UI development consists mainly of two dominant paradigms: retained mode and immediate
 mode. Most traditional GUI libraries operate under the retained mode paradigm. However, `ratatui`
-employs the immediate mode rendering approach. for TUI development.
+employs the immediate mode rendering approach for TUI development.
 
 This makes `ratatui` different from GUI frameworks you might use, because it only updates when you
 tell it to.


### PR DESCRIPTION

Changes:
- remove a period in the middle of a sentence on the 'Rendering' concepts page

Notes:
- I didn't do any local testing/spinning up of the docs here, so I'm assuming this is the right file/place to make this update. If not, please let me know - happy to update the PR!