### PR TITLE
chore(ci): add npm CI

### DIFF
--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -18,15 +18,29 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+  check:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install
         run: npm ci
-      - name: Check & build
-        run: npm run build
+      - name: Check
+        run: npm run astro check
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      # We use this action because github counts LFS bandwidth from CI.
+      # This action caches LFS downloads.
+      # See https://github.com/actions/checkout/issues/165
+      # If it ends up using too much bandwidth anyway, just delete this check.
+      - name: Checkout
+        uses: nschloe/action-cached-lfs-checkout@v1
+      - name: Install
+        run: npm ci
+      - name: Build
+        run: npm run astro build
 
   format:
     runs-on: ubuntu-latest

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -1,4 +1,4 @@
-name: Continuous Integration
+name: Npm Continuous Integration
 
 on:
   # Allows you to run this workflow manually from the Actions tab
@@ -18,36 +18,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  fmt:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Install Rust nightly
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install
+        run: npm ci
+      - name: Check & build
+        run: npm run build
 
-      - name: Check formatting
-        run: cargo fmt --all --check
-
-  typos:
+  format:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check typos
-        uses: crate-ci/typos@master
-
-  clippy:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-
-      - name: Run cargo clippy
-        run: cargo clippy -- -D warnings
+      - name: Install
+        run: npm ci
+      - name: Check format
+        run: npm run format:check

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -1,4 +1,4 @@
-name: Npm Continuous Integration
+name: Npm CI
 
 on:
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,0 +1,53 @@
+name: Rust Continuous Integration
+
+on:
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  merge_group:
+
+# ensure that the workflow is only triggered once per PR,  subsequent pushes to the PR will cancel
+# and restart the workflow. See https://docs.github.com/en/actions/using-jobs/using-concurrency
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all --check
+
+  typos:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check typos
+        uses: crate-ci/typos@master
+
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Run cargo clippy
+        run: cargo clippy -- -D warnings

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,4 +1,4 @@
-name: Rust Continuous Integration
+name: Rust CI
 
 on:
   # Allows you to run this workflow manually from the Actions tab

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "preview": "astro preview",
     "astro": "astro",
     "prepare": "husky install",
-    "format": "prettier --write . --plugin=prettier-plugin-astro --plugin=prettier-plugin-svelte --plugin=prettier-plugin-organize-imports --plugin=prettier-plugin-tailwindcss"
+    "_format": "prettier . --plugin=prettier-plugin-astro --plugin=prettier-plugin-svelte --plugin=prettier-plugin-organize-imports --plugin=prettier-plugin-tailwindcss",
+    "format": "npm run _format -- --write",
+    "format:check": "npm run _format -- --check"
   },
   "dependencies": {
     "@astrojs/check": "^0.4.1",

--- a/src/content/docs/faq.md
+++ b/src/content/docs/faq.md
@@ -421,9 +421,10 @@ easily make `stderr` buffered too by wrapping it in a [`BufWriter`] like so:
 let mut terminal = Terminal::new(CrosstermBackend::new(BufWriter::new(std::io::stderr())))?;
 ```
 
-Our recommendation is to use `stdout`. If you really need `stderr`, then accept the performance
-loss (which is unnoticeable in most applications) or make it buffered.
+Our recommendation is to use `stdout`. If you really need `stderr`, then accept the performance loss
+(which is unnoticeable in most applications) or make it buffered.
 
-If you want to know more, we recommend reading [this excellent article by @orhun](https://blog.orhun.dev/stdout-vs-stderr/).
+If you want to know more, we recommend reading
+[this excellent article by @orhun](https://blog.orhun.dev/stdout-vs-stderr/).
 
 [`BufWriter`]: https://doc.rust-lang.org/std/io/struct.BufWriter.html

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,8 +5,8 @@
     "paths": {
       "@components/*": ["src/components/*"],
       "@assets/*": ["src/assets/*"],
-      "@code/*": ["src/code/*"]
-    }
+      "@code/*": ["src/code/*"],
+    },
   },
-  "exclude": ["dist"]
+  "exclude": ["dist"],
 }


### PR DESCRIPTION
This will enable us to consistently check that the website can be built and is correctly formatted.

This is useful for contributors but also a lot for dependabot, e.g. https://github.com/ratatui-org/website/pull/384, https://github.com/ratatui-org/website/pull/385