### PR TITLE
Terminon to termion typo fix

### DIFF
--- a/src/content/docs/installation/feature-flags.md
+++ b/src/content/docs/installation/feature-flags.md
@@ -16,7 +16,7 @@ termwiz
 cargo add ratatui
 
 # For termion, unset the default crossterm feature and select the termion feature
-cargo add ratatui --no-default-features --features=terminon
+cargo add ratatui --no-default-features --features=termion
 cargo add termion
 
 # For termwiz, unset the default crossterm feature and select the termwiz feature


### PR DESCRIPTION
Fixed the typo in the features section where termion is written as terminon