### PR TITLE
fix: bug in code import where second import is ignored

### DIFF
--- a/src/plugins/remark-code-import.ts
+++ b/src/plugins/remark-code-import.ts
@@ -20,7 +20,7 @@ interface CodeNode extends Node {
 // - {{#include @path/to/file}} - path to file from root directory
 const pathRegex = rx`(?<path>.+?)`; // Matches at least one character, but as few as possible
 const anchorNameRegex = rx`(?<anchor>.*?)`; // Matches at least one character, but as few as possible
-const includeRegex = rx`   // global (matches all instances in the file)
+const includeRegex = rx`    // global (matches all instances in the file)
   \{\{                      // literal "{{"
   \s*                       // optional whitespace
   #include                  // literal "#include"

--- a/src/plugins/remark-code-import.ts
+++ b/src/plugins/remark-code-import.ts
@@ -20,7 +20,7 @@ interface CodeNode extends Node {
 // - {{#include @path/to/file}} - path to file from root directory
 const pathRegex = rx`(?<path>.+?)`; // Matches at least one character, but as few as possible
 const anchorNameRegex = rx`(?<anchor>.*?)`; // Matches at least one character, but as few as possible
-const includeRegex = rx.g`  // global (matches all instances in the file)
+const includeRegex = rx`  // global (matches all instances in the file)
   \{\{                      // literal "{{"
   \s*                       // optional whitespace
   #include                  // literal "#include"

--- a/src/plugins/remark-code-import.ts
+++ b/src/plugins/remark-code-import.ts
@@ -20,7 +20,7 @@ interface CodeNode extends Node {
 // - {{#include @path/to/file}} - path to file from root directory
 const pathRegex = rx`(?<path>.+?)`; // Matches at least one character, but as few as possible
 const anchorNameRegex = rx`(?<anchor>.*?)`; // Matches at least one character, but as few as possible
-const includeRegex = rx`  // global (matches all instances in the file)
+const includeRegex = rx`   // global (matches all instances in the file)
   \{\{                      // literal "{{"
   \s*                       // optional whitespace
   #include                  // literal "#include"


### PR DESCRIPTION
Using `global` regex match in combination with `exec` seems to cause unintended behavior when matching multiple anchors in the same code block.

For example, the following:

````
```rust
{{#include @code/crates-tui-tutorial-app/src/bin/part-helper.rs:crates_query}}

{{#include @code/crates-tui-tutorial-app/src/bin/part-helper.rs:crates_response}}
```
````

renders this:

<img width="750" alt="image" src="https://github.com/ratatui-org/website/assets/1813121/f9624801-3bd8-4282-8aa6-5a7b128d7f02">

I added a `console.log()` inside the `while` loop to confirm that the `match` is misbehaving:

```javascript
     while ((match = includeRegex.exec(node.value)) !== null) {
        console.log(match);
```

With `rx.g`:

<img width="741" alt="image" src="https://github.com/ratatui-org/website/assets/1813121/c3a977aa-c47b-4058-a5bc-4c662ff07929">

With just `rx` (i.e. removing global match), i.e. this PR:

<img width="742" alt="image" src="https://github.com/ratatui-org/website/assets/1813121/6e60e005-14ce-4a42-a976-3322fe9eb67d">

With this change it renders as intended.

<img width="745" alt="image" src="https://github.com/ratatui-org/website/assets/1813121/fcccb1c3-b1fc-4420-829e-5dbb6e4b140b">
