### PR TITLE
consistent counter app snippets and full code

### DIFF
--- a/src/content/docs/tutorials/counter-app/multiple-functions.md
+++ b/src/content/docs/tutorials/counter-app/multiple-functions.md
@@ -143,13 +143,13 @@ fn run() -> Result<()> {
   let mut app = App { counter: 0, should_quit: false };
 
   loop {
+    // application update
+    update(&mut app)?;
+
     // application render
     t.draw(|f| {
       ui(&app, f);
     })?;
-
-    // application update
-    update(&mut app)?;
 
     // application exit
     if app.should_quit {


### PR DESCRIPTION
This is a very minor change, I noticed that the order of the functions in the main loop is different between the snippets and the final full code for reference.