### PR TITLE
fix: Remove text referencing centered rect

### DIFF
--- a/src/content/docs/tutorials/json-editor/ui-editing.md
+++ b/src/content/docs/tutorials/json-editor/ui-editing.md
@@ -10,8 +10,7 @@ create the appearance of a popup.
 ## Popup area and title
 
 The first thing we will do, is draw the `Block` that will contain the popup. We will give this
-`Block` a title to display as well to explain to the user what it is. (We will cover `centered_rect`
-below)
+`Block` a title to display as well to explain to the user what it is.
 
 ```rust
 {{#include @code/ratatui-json-editor-app/src/ui.rs:editing_popup}}


### PR DESCRIPTION
Fixes https://github.com/ratatui-org/website/issues/454

Centered Rect is defined in the tutorial in ./ui.md