### PR TITLE
fix: Markdown link was incorrect

### DIFF
--- a/src/content/docs/showcase/widgets/index.mdx
+++ b/src/content/docs/showcase/widgets/index.mdx
@@ -61,7 +61,7 @@ https://github.com/ratatui-org/website/issues/249 for information about how to c
 
 ## Tabs <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Tabs.html" text="Docs" />
 
-![Tabs(./tabs.png)
+![Tabs](./tabs.png)
 
 ## Third Party Widgets
 


### PR DESCRIPTION
My PR #391 was merged and I checked the website and noticed that the `tabs.png` link was broken 😅 


Also, sorry I wasn't able to update the showcase with the suggestions as life got busy with work & raising a teething baby. 