### PR TITLE
fix: incorrect fn naming for counter app

### DIFF
--- a/code/counter-app-basic/src/main.rs
+++ b/code/counter-app-basic/src/main.rs
@@ -68,8 +68,8 @@ impl App {
     fn handle_key_event(&mut self, key_event: KeyEvent) {
         match key_event.code {
             KeyCode::Char('q') => self.exit(),
-            KeyCode::Left => self.increment_counter(),
-            KeyCode::Right => self.decrement_counter(),
+            KeyCode::Left => self.decrement_counter(),
+            KeyCode::Right => self.increment_counter(),
             _ => {}
         }
     }
@@ -80,11 +80,11 @@ impl App {
         self.exit = true;
     }
 
-    fn decrement_counter(&mut self) {
+    fn increment_counter(&mut self) {
         self.counter += 1;
     }
 
-    fn increment_counter(&mut self) {
+    fn decrement_counter(&mut self) {
         self.counter -= 1;
     }
     // ANCHOR_END: methods


### PR DESCRIPTION
The code for the basic counter app has incorrectly named the decrement counter function as `increment_counter` and the increment counter function as `decrement_counter`. This PR resolves the naming issues.