### PR TITLE
docs: add details for installing package and fix typo

### DIFF
--- a/src/content/docs/tutorials/counter-app/error-handling/index.md
+++ b/src/content/docs/tutorials/counter-app/error-handling/index.md
@@ -63,7 +63,13 @@ One approach that makes it easy to show unhandled errors is to use the `color_ey
 the error reporting hooks. In a ratatui application that's running on the alternate screen in raw
 mode, it's important to restore the terminal before displaying these errors to the user.
 
-Add a new module nameds errors to `main.rs`.
+Add the `color_eyre` crate
+
+```shell title="add color_eyre"
+cargo add color_eyre
+```
+
+Add a new module named errors to `main.rs`.
 
 ```rust
 // main.rs

--- a/src/content/docs/tutorials/counter-app/error-handling/index.md
+++ b/src/content/docs/tutorials/counter-app/error-handling/index.md
@@ -63,10 +63,10 @@ One approach that makes it easy to show unhandled errors is to use the `color_ey
 the error reporting hooks. In a ratatui application that's running on the alternate screen in raw
 mode, it's important to restore the terminal before displaying these errors to the user.
 
-Add the `color_eyre` crate
+Add the `color-eyre` crate
 
-```shell title="add color_eyre"
-cargo add color_eyre
+```shell title="add color-eyre"
+cargo add color-eyre
 ```
 
 Add a new module named errors to `main.rs`.


### PR DESCRIPTION
This PR:
- [x] Adds a block telling the reader to install color_eyre`
- [x] Fixes a minor typo (`nameds` -> `named`)

Sorry I didn't bundle these with https://github.com/ratatui-org/website/pull/484, editing as I go through the tutorials. 😅 