### PR TITLE
chore: Add is:inline for partytown

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -14,6 +14,7 @@ const buttons = [
 ---
 
 <script
+  is:inline
   type="text/partytown"
   src="https://umami.orhun.dev/script.js"
   data-website-id="3f27a7c3-d24f-4869-a371-8a6ba8ec6932"></script>


### PR DESCRIPTION
I was getting a warning without this attribute

<img width="758" alt="image" src="https://github.com/ratatui-org/website/assets/1813121/7dc3c82c-5872-40e1-83e4-bb3856f71a0d">
