### PR TITLE
Rename repo to ratatui-website

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ To read this content online, visit:
 To build and run the site locally:
 
 ```shell
-git clone https://github.com/ratatui-org/website/
+git clone https://github.com/ratatui-org/ratatui-website/
 cd website
 
 git lfs install

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -295,7 +295,7 @@ export default defineConfig({
         },
       ],
       editLink: {
-        baseUrl: "https://github.com/ratatui-org/website/edit/main/",
+        baseUrl: "https://github.com/ratatui-org/ratatui-website/edit/main/",
       },
     }),
     tailwind({

--- a/src/content/docs/developer-guide/website.mdx
+++ b/src/content/docs/developer-guide/website.mdx
@@ -5,8 +5,8 @@ title: Website
 [ratatui.rs](https://ratatui.rs) is built with [`Astro`](https://astro.build/) and
 [`Starlight`](https://starlight.astro.build).
 
-The source is available from the [ratatui-org/website](https://github.com/ratatui-org/website)
-GitHub repository.
+The source is available from the
+[ratatui-org/ratatui-website](https://github.com/ratatui-org/ratatui-website) GitHub repository.
 
 If you would like to contribute, you can make a fork and clone the repository. Make sure you run the
 following [`git lfs`] commands before making a PR.

--- a/src/content/docs/highlights/v0.23.md
+++ b/src/content/docs/highlights/v0.23.md
@@ -230,7 +230,8 @@ past about using `unsafe` code for optimization purposes.
 We are working on a book for more in-depth `ratatui` documentation and usage examples, you can read
 it at <https://ratatui.rs/>
 
-Repository: [**https://github.com/ratatui-org/website**](https://github.com/ratatui-org/website)
+Repository:
+[**https://github.com/ratatui-org/ratatui-website**](https://github.com/ratatui-org/ratatui-website)
 
 ---
 

--- a/src/content/docs/highlights/v0.24.md
+++ b/src/content/docs/highlights/v0.24.md
@@ -12,10 +12,10 @@ for easily going through the breaking changes in each version.
 
 The site you are browsing right now (`ratatui.rs`) is the new homepage of `ratatui`! For now, we
 host the book here which contains a bunch of useful tutorials, concepts and FAQ sections and there
-is a [plan](https://github.com/ratatui-org/website/issues/115) to create a landing page
-[pretty soon](https://github.com/ratatui-org/website/pull/116)!
+is a [plan](https://github.com/ratatui-org/ratatui-website/issues/115) to create a landing page
+[pretty soon](https://github.com/ratatui-org/ratatui-website/pull/116)!
 
-All the code is available at <https://github.com/ratatui-org/website>
+All the code is available at <https://github.com/ratatui-org/ratatui-website>
 
 ---
 

--- a/src/content/docs/highlights/v0.25.md
+++ b/src/content/docs/highlights/v0.25.md
@@ -12,7 +12,7 @@ for this release.
 We revamped our entire website ([ratatui.rs](https://ratatui.rs)) with [Astro](https://astro.build/)
 and updated the documentation/tutorials.
 
-![image](https://github.com/ratatui-org/website/assets/24392180/bdff62e6-89d8-4d4e-9e25-d0652edffde4)
+![image](https://github.com/ratatui-org/ratatui-website/assets/24392180/bdff62e6-89d8-4d4e-9e25-d0652edffde4)
 
 Here are some of the sections that we recommend checking out:
 
@@ -21,10 +21,10 @@ Here are some of the sections that we recommend checking out:
 - [How-to](https://ratatui.rs/how-to/)
 - [Apps/Widgets Showcase](https://ratatui.rs/showcase/)
 
-All the code is available at <https://github.com/ratatui-org/website>
+All the code is available at <https://github.com/ratatui-org/ratatui-website>
 
-Check out the [good first issues here](https://github.com/ratatui-org/website/issues) if you are
-interested in contributing to our website!
+Check out the [good first issues here](https://github.com/ratatui-org/ratatui-website/issues) if you
+are interested in contributing to our website!
 
 ---
 
@@ -174,7 +174,7 @@ Layout::new(
 .split(frame.size());
 ```
 
-![SegmentSize::LastTakesRemainder](https://github.com/ratatui-org/website/assets/36198422/ef0f8c1c-c931-4ed9-b5a2-2ce6333285af)
+![SegmentSize::LastTakesRemainder](https://github.com/ratatui-org/ratatui-website/assets/36198422/ef0f8c1c-c931-4ed9-b5a2-2ce6333285af)
 
 `SegmentSize::None` will disable this behavior.
 
@@ -187,7 +187,7 @@ Layout::new(
 .split(frame.size());
 ```
 
-![SegmentSize::None](https://github.com/ratatui-org/website/assets/36198422/90b15c04-8a50-4f6e-98af-58b257575b90)
+![SegmentSize::None](https://github.com/ratatui-org/ratatui-website/assets/36198422/90b15c04-8a50-4f6e-98af-58b257575b90)
 
 To configure the layout to fill the remaining space evenly, use
 `Layout::segment_size(SegmentSize::EvenDistribution)`.

--- a/src/content/docs/highlights/v0.26.md
+++ b/src/content/docs/highlights/v0.26.md
@@ -73,7 +73,7 @@ based on [flexbox](https://css-tricks.com/snippets/css/a-guide-to-flexbox/):
 - `Flex::SpaceBetween`
 - `Flex::Legacy` (old default)
 
-![](https://github.com/ratatui-org/website/blob/38126ae809251619384e54856dcfa9dc07d3a177/src/content/docs/highlights/constraint-explorer.gif?raw=true)
+![](https://github.com/ratatui-org/ratatui-website/blob/38126ae809251619384e54856dcfa9dc07d3a177/src/content/docs/highlights/constraint-explorer.gif?raw=true)
 
 In addition to changing the default to `Flex::Start`, we have made a couple of changes to the
 constraints.

--- a/src/content/docs/how-to/develop-apps/color-eyre/index.md
+++ b/src/content/docs/how-to/develop-apps/color-eyre/index.md
@@ -3,7 +3,7 @@ title: How to use color_eyre with Ratatui
 ---
 
 Full source code for this how to article is available at:
-<https://github.com/ratatui-org/website/tree/main/code/how-to-color_eyre/>
+<https://github.com/ratatui-org/ratatui-website/tree/main/code/how-to-color_eyre/>
 
 The [`color_eyre`] crate provides error report handlers for panics and errors. It displays the
 reports formatted and in color. To use these handlers, a Ratatui app needs to restore the terminal

--- a/src/content/docs/how-to/layout/collapse-borders.md
+++ b/src/content/docs/how-to/layout/collapse-borders.md
@@ -71,7 +71,7 @@ If this sounds too complex, we're looking for some help to make this easier in
 :::
 
 The full code for this example is available at
-<https://github.com/ratatui-org/website/blob/main/code/how-to-collapse-borders>
+<https://github.com/ratatui-org/ratatui-website/blob/main/code/how-to-collapse-borders>
 
 Full `ui()` function:
 

--- a/src/content/docs/how-to/render/overwrite-regions.md
+++ b/src/content/docs/how-to/render/overwrite-regions.md
@@ -25,7 +25,7 @@ The following code exhibits this problem:
 {{#include @code/how-to-overwrite-regions/src/bin/problem.rs:ui}}
 ```
 
-![problem](https://github.com/ratatui-org/website/assets/381361/a32bd6e2-9704-4054-b41d-a34715fc217f)
+![problem](https://github.com/ratatui-org/ratatui-website/assets/381361/a32bd6e2-9704-4054-b41d-a34715fc217f)
 
 Notice that the background color (black in this case), the italics, and the lorem ipsum background
 text show through the popup.
@@ -49,10 +49,10 @@ We can use the new `Popup` widget with the following code:
 
 Which results in the following:
 
-![demo](https://github.com/ratatui-org/website/assets/381361/39e92dad-8127-4588-8361-45d2f95abf32)
+![demo](https://github.com/ratatui-org/ratatui-website/assets/381361/39e92dad-8127-4588-8361-45d2f95abf32)
 
 Notice that the background is set to the default background and there are no italics or symbols from
 the background text.
 
 Full source for this article is available at
-<https://github.com/ratatui-org/website/tree/main/code/how-to-overwrite-regions>
+<https://github.com/ratatui-org/ratatui-website/tree/main/code/how-to-overwrite-regions>

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -68,9 +68,9 @@ If you see something that could be better written, feel free to [create an issue
 thread] or even contribute a [Pull Request]. We're also often active in the `#doc-discussion`
 channel on [Discord] and [Matrix]
 
-[create an issue]: https://github.com/ratatui-org/website/issues
-[discussion thread]: https://github.com/ratatui-org/website/discussions
-[Pull Request]: https://github.com/ratatui-org/website/pulls
+[create an issue]: https://github.com/ratatui-org/ratatui-website/issues
+[discussion thread]: https://github.com/ratatui-org/ratatui-website/discussions
+[Pull Request]: https://github.com/ratatui-org/ratatui-website/pulls
 [Discord]: https://discord.gg/pMCEU9hNEj
 [Matrix]: https://matrix.to/#/#ratatui:matrix.org
 

--- a/src/content/docs/showcase/third-party-widgets/index.mdx
+++ b/src/content/docs/showcase/third-party-widgets/index.mdx
@@ -5,7 +5,7 @@ title: Third Party Widgets Showcase
 import LinkBadge from "/src/components/LinkBadge.astro";
 
 To add your widgets to this list, please read the
-[Third Party Widgets README](https://github.com/ratatui-org/website/tree/main/code/widget-showcase-third-party/README.md)
+[Third Party Widgets README](https://github.com/ratatui-org/ratatui-website/tree/main/code/widget-showcase-third-party/README.md)
 
 ## Ratatui-image <LinkBadge text="Crate" href="https://crates.io/crates/ratatui-image" /> <LinkBadge text="Docs" href="https://docs.rs/ratatui-image" /> <LinkBadge text="GitHub" href="https://github.com/benjajaja/ratatui-image" />
 

--- a/src/content/docs/showcase/widgets/index.mdx
+++ b/src/content/docs/showcase/widgets/index.mdx
@@ -8,9 +8,9 @@ The following widgets are built-in and available in the `ratatui` crate. They ar
 the [API docs](https://docs.rs/ratatui/latest/ratatui/widgets/index.html).
 
 Note: these screenshots are created using the [widget-showcase] project and [VHS]. See
-https://github.com/ratatui-org/website/issues/249 for information about how to contribute.
+https://github.com/ratatui-org/ratatui-website/issues/249 for information about how to contribute.
 
-[widget-showcase]: https://github.com/ratatui-org/website/blob/main/code/widget-showcase
+[widget-showcase]: https://github.com/ratatui-org/ratatui-website/blob/main/code/widget-showcase
 [VHS]: https://github.com/charmbracelet/vhs
 
 ## Block <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/block/struct.Block.html" text="Docs" />
@@ -49,7 +49,7 @@ https://github.com/ratatui-org/website/issues/249 for information about how to c
 
 ![Paragraph](./paragraph.png)
 
-## Scrollbar <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Scrollbar.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/website/issues/249" variant="caution" />
+## Scrollbar <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Scrollbar.html" text="Docs" /> <LinkBadge text="Help Wanted" href="https://github.com/ratatui-org/ratatui-website/issues/249" variant="caution" />
 
 ## Sparkline <LinkBadge href="https://docs.rs/ratatui/latest/ratatui/widgets/struct.Sparkline.html" text="Docs" />
 

--- a/src/content/docs/templates/component/index.md
+++ b/src/content/docs/templates/component/index.md
@@ -156,8 +156,8 @@ You may also want to check out the following links (roughly in order of increasi
 - <https://github.com/ratatui-org/templates/tree/main/simple>: Starter kit for using `ratatui`
 - <https://github.com/ratatui-org/templates/tree/main/async>: Starter kit for using `ratatui` with
   `async` using `tokio`
-- <https://github.com/ratatui-org/website/tree/main/code/ratatui-json-editor-app>: Tutorial project
-  that the user a simple interface to enter key-value pairs, which will printed in json.
+- <https://github.com/ratatui-org/ratatui-website/tree/main/code/ratatui-json-editor-app>: Tutorial
+  project that the user a simple interface to enter key-value pairs, which will printed in json.
 - <https://github.com/ratatui-org/templates/tree/main/component>: Async tokio crossterm based
   opinionated starter kit with "components" for using `ratatui`.
 - <https://github.com/veeso/tui-realm/>: A framework for `tui.rs` to simplify the implementation of

--- a/src/content/docs/tutorials/counter-app/basic-app/index.md
+++ b/src/content/docs/tutorials/counter-app/basic-app/index.md
@@ -5,7 +5,7 @@ description: This tutorial covers a basic counter application with Ratatui
 
 A full copy of the code for this page is available in the github repository for the website at:
 
-<https://github.com/ratatui-org/website/tree/main/code/counter-app-basic>.
+<https://github.com/ratatui-org/ratatui-website/tree/main/code/counter-app-basic>.
 
 ## Create a new project
 

--- a/src/content/docs/tutorials/counter-app/error-handling/index.md
+++ b/src/content/docs/tutorials/counter-app/error-handling/index.md
@@ -4,7 +4,7 @@ title: Counter App Error Handling
 
 A full copy of the code for this page is available in the github repository for the website at:
 
-<https://github.com/ratatui-org/website/tree/main/code/counter-app-error-handling>.
+<https://github.com/ratatui-org/ratatui-website/tree/main/code/counter-app-error-handling>.
 
 In the previous section, you created a [basic counter app](../basic-app/) that responds to the user
 pressing a the **Left** and **Right** arrow keys to control the value of a counter. This tutorial

--- a/src/content/docs/tutorials/counter-app/multiple-files/index.md
+++ b/src/content/docs/tutorials/counter-app/multiple-files/index.md
@@ -22,7 +22,7 @@ $ tree .
 ```
 
 If you want to explore the code on your own, you can check out the completed source code here:
-<https://github.com/ratatui-org/website/tree/main/code/ratatui-counter-app>
+<https://github.com/ratatui-org/ratatui-website/tree/main/code/ratatui-counter-app>
 
 Let's go ahead and declare these files as modules in `src/main.rs`
 

--- a/src/content/docs/tutorials/counter-app/multiple-files/main.md
+++ b/src/content/docs/tutorials/counter-app/multiple-files/main.md
@@ -45,7 +45,7 @@ Sleep 2.5s
 ![Counter app demo](https://user-images.githubusercontent.com/1813121/263404720-41bd81a0-4eec-479c-9333-44363a183613.gif)
 
 You can find the full source code for this multiple files tutorial here:
-<https://github.com/ratatui-org/website/tree/main/code/ratatui-counter-app>.
+<https://github.com/ratatui-org/ratatui-website/tree/main/code/ratatui-counter-app>.
 
 :::note[Homework]
 

--- a/src/content/docs/tutorials/hello-world.md
+++ b/src/content/docs/tutorials/hello-world.md
@@ -10,10 +10,10 @@ understanding of the terminal, and have a text editor or Rust IDE. If you don't 
 
 You're going to build the following:
 
-![hello](https://github.com/ratatui-org/website/assets/381361/b324807e-915f-45b3-a4a2-d3b419eec387)
+![hello](https://github.com/ratatui-org/ratatui-website/assets/381361/b324807e-915f-45b3-a4a2-d3b419eec387)
 
 The full code for this tutorial is available to view at
-<https://github.com/ratatui-org/website/tree/main/code/hello-world-tutorial>
+<https://github.com/ratatui-org/ratatui-website/tree/main/code/hello-world-tutorial>
 
 ## Install Rust
 
@@ -269,7 +269,7 @@ cargo run
 You should see a TUI app with `Hello Ratatui! (press 'q' to quit)` show up in your terminal as a TUI
 app.
 
-![hello](https://github.com/ratatui-org/website/assets/381361/98eee556-6283-4aa5-a068-99392e1a5dda)
+![hello](https://github.com/ratatui-org/ratatui-website/assets/381361/98eee556-6283-4aa5-a068-99392e1a5dda)
 
 You can press `q` to exit and go back to your terminal as it was before.
 

--- a/src/content/docs/tutorials/json-editor/closing-thoughts.md
+++ b/src/content/docs/tutorials/json-editor/closing-thoughts.md
@@ -12,8 +12,8 @@ inspiration for what model will work best for your application.
 ## Finished Files
 
 You can find the finished project used for the tutorial on
-[GitHub](https://github.com/ratatui-org/website/tree/main/code/ratatui-json-editor-app). The code is
-also shown at the bottom of this page.
+[GitHub](https://github.com/ratatui-org/ratatui-website/tree/main/code/ratatui-json-editor-app). The
+code is also shown at the bottom of this page.
 
 You can test this application by yourself by running:
 


### PR DESCRIPTION
Fixup the links and references to the old repository name in the
documentation and configuration files.