### PR TITLE
Fix markdown-generated SVG issues on dark mode

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -16,3 +16,26 @@
     width: min(100%, 25rem);
   }
 }
+
+/* Fix for SVGBob diagrams on dark mode */
+.content-panel svg text,
+.content-panel svg .filled {
+  fill: currentColor;
+}
+.content-panel svg .solid,
+.content-panel svg polygon {
+  stroke: currentColor;
+}
+
+/* Fix for SVGBob styles leaking into other SVGs */
+:not(.sl-markdown-content span > svg path) {
+  stroke: none;
+}
+
+/* Fix for Mermaid diagrams on dark mode */
+svg[aria-roledescription="flowchart-v2"] .flowchart-link {
+  stroke: currentColor !important;
+}
+svg[aria-roledescription="flowchart-v2"] .arrowMarkerPath {
+  fill: currentColor;
+}

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -33,9 +33,23 @@
 }
 
 /* Fix for Mermaid diagrams on dark mode */
-svg[aria-roledescription="flowchart-v2"] .flowchart-link {
+svg[aria-roledescription="sequence"] .messageText {
+  fill: currentColor !important;
+}
+svg[aria-roledescription="sequence"] line,
+svg[aria-roledescription="sequence"] path,
+svg[aria-roledescription="sequence"] .flowchart-link {
   stroke: currentColor !important;
 }
 svg[aria-roledescription="flowchart-v2"] .arrowMarkerPath {
   fill: currentColor;
+}
+svg[aria-roledescription="flowchart-v2"] line,
+svg[aria-roledescription="flowchart-v2"] path,
+svg[aria-roledescription="flowchart-v2"] .flowchart-link {
+  stroke: currentColor !important;
+}
+marker#arrowhead path {
+  fill: currentColor !important;
+  stroke: currentColor !important;
 }


### PR DESCRIPTION
The markdown currently makes use of mermaid diagrams and SVGBob outputs. 

Unfortunately:
- SVGBob is not theme-aware
- Mermaid diagrams are hard-coded for light mode
- SVGBob leaks all its styles to other SVGs (the header)

We might want to consider an astro plugin to change SVGBob's generated styles, but this fix should be simple enough to suffice for now.

| Before      | After |
| ----------- | ----------- |
| ![Buffer Before]      | ![Buffer After]       |
| ![Header Before]  | ![Header After]        |
| ![Mermaid Before] | ![Mermaid After] |
| ![Mermaid Seq Before] | ![Mermaid Seq After] |

 <!----------------------------------------------------------------------------->
[Buffer Before]: https://github.com/ratatui-org/ratatui-website/assets/24513691/0599ca02-1eb1-45c4-bf09-8f935017bd5e
[Buffer After]: https://github.com/ratatui-org/ratatui-website/assets/24513691/a671ae94-46ed-4a9b-9b0c-42e325f20640

[Header Before]: https://github.com/ratatui-org/ratatui-website/assets/24513691/e456eee9-1cad-435c-ae76-a6eff0ebdd56
[Header After]: https://github.com/ratatui-org/ratatui-website/assets/24513691/3b2e5b86-cc0a-4cf0-86dd-0ade23b28563

[Mermaid Before]: https://github.com/ratatui-org/ratatui-website/assets/24513691/f98ef06a-5a5c-4512-84b1-38916a97bb4e
[Mermaid After]: https://github.com/ratatui-org/ratatui-website/assets/24513691/b0675220-e5b5-49dc-99e0-be913ba8beea

[Mermaid Seq Before]: https://github.com/ratatui-org/ratatui-website/assets/24513691/fde53856-7a16-4775-b3f5-47b0c09731ae
[Mermaid Seq After]:  https://github.com/ratatui-org/ratatui-website/assets/24513691/0f1f453b-1497-488c-82e4-2d863536864d



