### PR TITLE
Chore: bump remark-svgbob

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3593,16 +3593,6 @@
         "readable-stream": "^3.4.0"
       }
     },
-    "node_modules/bob-wasm": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bob-wasm/-/bob-wasm-1.0.1.tgz",
-      "integrity": "sha512-MmuVQCBQJgyRO8qg6Qm+yVq4dv6CtrM3rQNDYPJoco9vTFGDwkQGrmPSACLPRnhCDD3h/ng9ndxfRo4wlXPe0g==",
-      "dependencies": {
-        "decode-base64": "^3.0.1",
-        "function-once": "^3.0.0",
-        "uint8-encoding": "^2.0.0"
-      }
-    },
     "node_modules/boolbase": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
@@ -4739,14 +4729,6 @@
         }
       }
     },
-    "node_modules/decode-base64": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/decode-base64/-/decode-base64-3.0.1.tgz",
-      "integrity": "sha512-IWgiXlMAdm9c4RrOnvkFxYpfZRlOys4Wxnc/QT72hVLUZKCr7RPkfamgn2GXysCo06Zd4TGZyKaPHO4soBgSAg==",
-      "dependencies": {
-        "node-buffer-encoding": "^1.0.1"
-      }
-    },
     "node_modules/decode-named-character-reference": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
@@ -5323,11 +5305,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/function-once": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/function-once/-/function-once-3.0.0.tgz",
-      "integrity": "sha512-WEhgu9PE55sHFf+SBg3lI8+CWpsqReLcsp3g12XhwSJJgnodpSpHk6StvpeVcKuHAFCAdttLrslJRFDSdLDf4g=="
     },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
@@ -8372,11 +8349,6 @@
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "optional": true
     },
-    "node_modules/node-buffer-encoding": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/node-buffer-encoding/-/node-buffer-encoding-1.0.1.tgz",
-      "integrity": "sha512-eklg9A4yXOlIZOIeV8D33gHZjw2g61TREuhucTM+/OR/xn4MXTZaV60fEYP+Lsa7C9bliJvvNrgkC6igafgKrw=="
-    },
     "node_modules/node-emoji": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.1.3.tgz",
@@ -10178,11 +10150,10 @@
       }
     },
     "node_modules/remark-svgbob": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/remark-svgbob/-/remark-svgbob-1.0.6.tgz",
-      "integrity": "sha512-hOvlLFHUDF+Qi3NWgcifgv5AHzX5/hIhLTm4uWf+Gbl8WauMgWKXw2OzN6AcDd13Te9lk5ejW+jjQwmxEBfVOQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/remark-svgbob/-/remark-svgbob-1.1.0.tgz",
+      "integrity": "sha512-WiXCKuU8qAU9pSChrJxcSl244zDc4+QhJHo+cJ06IeSIShvdqMVLtFeCu+LTVvqjpNQVbmYauejKqE7nDtp/kQ==",
       "dependencies": {
-        "bob-wasm": "^1.0.1",
         "unist-util-visit": "^5.0.0"
       }
     },
@@ -11727,11 +11698,6 @@
       "dependencies": {
         "semver": "^7.3.8"
       }
-    },
-    "node_modules/uint8-encoding": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/uint8-encoding/-/uint8-encoding-2.0.0.tgz",
-      "integrity": "sha512-MQcY+mEuLoHBqAawasWrFbZx1SqUoFU/wVYNGO6lsIxczeO+cNjA1djYHQM3GWU3SaEhKTfG3Z5cE2r+zR6tNw=="
     },
     "node_modules/unbzip2-stream": {
       "version": "1.4.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "astro-diagram": "^0.7.0",
         "hast-util-select": "^6.0.2",
         "hastscript": "^9.0.0",
-        "remark-svgbob": "^1.0.6",
+        "remark-svgbob": "^1.1.1",
         "sharp": "^0.33.2",
         "starlight-links-validator": "^0.6.0",
         "tailwindcss": "^3.4.1",
@@ -10150,9 +10150,9 @@
       }
     },
     "node_modules/remark-svgbob": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/remark-svgbob/-/remark-svgbob-1.1.0.tgz",
-      "integrity": "sha512-WiXCKuU8qAU9pSChrJxcSl244zDc4+QhJHo+cJ06IeSIShvdqMVLtFeCu+LTVvqjpNQVbmYauejKqE7nDtp/kQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/remark-svgbob/-/remark-svgbob-1.1.1.tgz",
+      "integrity": "sha512-0bWW4ax/QjDWHMwvu23f2LjS/y5il1mgdOmxDqj69nvnAGemYKCMNwoX65DdZV/CB+dFVxh+fyAt0emBwFvD0Q==",
       "dependencies": {
         "unist-util-visit": "^5.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "astro-diagram": "^0.7.0",
     "hast-util-select": "^6.0.2",
     "hastscript": "^9.0.0",
-    "remark-svgbob": "^1.0.6",
+    "remark-svgbob": "^1.1.0",
     "sharp": "^0.33.2",
     "starlight-links-validator": "^0.6.0",
     "tailwindcss": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "astro-diagram": "^0.7.0",
     "hast-util-select": "^6.0.2",
     "hastscript": "^9.0.0",
-    "remark-svgbob": "^1.1.0",
+    "remark-svgbob": "^1.1.1",
     "sharp": "^0.33.2",
     "starlight-links-validator": "^0.6.0",
     "tailwindcss": "^3.4.1",

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -18,18 +18,13 @@
 }
 
 /* Fix for SVGBob diagrams on dark mode */
-.content-panel svg text,
-.content-panel svg .filled {
+svg.svgbob text,
+svg.svgbob .filled {
   fill: currentColor;
 }
-.content-panel svg .solid,
-.content-panel svg polygon {
+svg.svgbob .solid,
+svg.svgbob polygon {
   stroke: currentColor;
-}
-
-/* Fix for SVGBob styles leaking into other SVGs */
-:not(.sl-markdown-content span > svg path) {
-  stroke: none;
 }
 
 /* Fix for Mermaid diagrams on dark mode */


### PR DESCRIPTION
This bumps remark-svgbob to use the new version with proper style scoping. 
The previous PR used some custom styles to prevent this, but they weren't perfect and resulted in some slight changes that this fixes (note the stroke thickness on the arrowheads).

| before | after |
|-----|----|
|![image Before] | ![image After]

[Image Before]: https://github.com/ratatui-org/ratatui-website/assets/24513691/3b07c1af-5307-431a-9338-8226fd3c1ee0
[Image After]: https://github.com/ratatui-org/ratatui-website/assets/24513691/fc86bda6-92ec-42bd-8794-4d804b933460

It also lets us make our styles more specific to SVGBob SVGs. Before our styles may have accidentally affected all SVGs inside our article since we weren't able to target a more specific selector.
