### PR TITLE
docs: fix bugs in async increment example

### DIFF
--- a/src/content/docs/tutorials/counter-async-app/async-increment-decrement.md
+++ b/src/content/docs/tutorials/counter-async-app/async-increment-decrement.md
@@ -106,12 +106,13 @@ fn handle_event(app: &App, tx: mpsc::UnboundedSender<Action>) -> tokio::task::Jo
     loop {
       let action = if crossterm::event::poll(tick_rate).unwrap() {
         if let crossterm::event::Event::Key(key) = crossterm::event::read().unwrap() {
-          if key.kind == event::KeyEventKind::Press {
+          if key.kind == crossterm::event::KeyEventKind::Press {
             match key.code {
               crossterm::event::KeyCode::Char('j') => Action::ScheduleIncrement,
               crossterm::event::KeyCode::Char('k') => Action::ScheduleDecrement,
               crossterm::event::KeyCode::Char('q') => Action::Quit,
               _ => Action::None,
+            }
           } else {
             Action::None
           }


### PR DESCRIPTION
Hey there! I believe I may have found some typos in this example. Very new to rust, but I think `event::KeyEventkind::Press` should be coming from `crossenv`, and the match was missing a `RCURLY`

