### PR TITLE
docs: refactor bullet-list format and text in introduction

### DIFF
--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -29,7 +29,7 @@ based on components, Flux and The Elm Architecture.
 Ratatui is designed for developers and enthusiasts who:
 
 - want a lightweight alternative to graphical user interfaces (GUIs)
-- need applications that are to be deployed in constrained environments (for ex. on servers with
+- need applications that are to be deployed in constrained environments (e.g. on servers with
   limited resources)
 - prefer to have full control over input and events, allowing for a more customized and tailored
   user experience

--- a/src/content/docs/introduction.md
+++ b/src/content/docs/introduction.md
@@ -28,12 +28,12 @@ based on components, Flux and The Elm Architecture.
 
 Ratatui is designed for developers and enthusiasts who:
 
-- want a lightweight alternative to graphical user interfaces (GUIs),
-- need applications that are to be deployed in constrained environments, like on servers with
-  limited resources, and
+- want a lightweight alternative to graphical user interfaces (GUIs)
+- need applications that are to be deployed in constrained environments (for ex. on servers with
+  limited resources)
 - prefer to have full control over input and events, allowing for a more customized and tailored
-  user experience.
-- appreciate the retro aesthetic of the terminal,
+  user experience
+- appreciate the retro aesthetic of the terminal
 
 ## Who is this book for?
 


### PR DESCRIPTION
The [introduction page](https://ratatui.rs/introduction/) has several elements with bullet-list formats,
The goal here is to format the second bullet-list so that it follows the same convention as the other ones on the page (no commas or dots at the end of line of its items). 
Also, the second item from the concerned bullet-list should be refactored so that it is consistent with the first item (added parentheses instead of commas for the example)