### PR TITLE
Fixed link to "How-To" section of docs

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -35,7 +35,7 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
   <Card title="<a href='/tutorials/hello-world/'>Hello World Tutorial</a>" icon="pencil" />
   <Card title="<a href='/tutorials/counter-app/'>Counter App Tutorial</a>" icon="document" />
   <Card title="<a href='/concepts/layout/'>Advanced Concepts</a>" icon="open-book" />
-  <Card title="<a href='/how-to/layout/dynamic/'>How To Guides</a>" icon="magnifier" />
+  <Card title="<a href='/how-to/'>How To Guides</a>" icon="magnifier" />
   <Card title="<a href='https://docs.rs/ratatui/latest/ratatui/'>API Reference</a>" icon="puzzle" />
   <Card title="<a href='/showcase/'>Community Showcase</a>" icon="list-format" />
   <Card


### PR DESCRIPTION
The button on the main page labeled **How-To** is actually hyperlinked to `https://ratatui.rs/how-to/layout/dynamic/`, which is not the main page of the "How-To" section of the docs. This PR fixes the link by changing the link from `/how-to/layout/dynamic/` to `/how-to/`.