### PR TITLE
fix: use serde_json::Result<> in app.rs in json-editor-app

### DIFF
--- a/code/ratatui-json-editor-app/src/app.rs
+++ b/code/ratatui-json-editor-app/src/app.rs
@@ -1,10 +1,5 @@
 use std::collections::HashMap;
 
-// ANCHOR: all
-// ANCHOR: imports
-use serde_json::Result;
-// ANCHOR_END: imports
-
 // ANCHOR: screen_modes
 pub enum CurrentScreen {
     Main,
@@ -72,7 +67,7 @@ impl App {
     // ANCHOR_END: toggle_editing
 
     // ANCHOR: print_json
-    pub fn print_json(&self) -> Result<()> {
+    pub fn print_json(&self) -> serde_json::Result<()> {
         let output = serde_json::to_string(&self.pairs)?;
         println!("{}", output);
         Ok(())

--- a/code/ratatui-json-editor-app/src/app.rs
+++ b/code/ratatui-json-editor-app/src/app.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+// ANCHOR: all
 // ANCHOR: screen_modes
 pub enum CurrentScreen {
     Main,


### PR DESCRIPTION
It took me a while to figure out that it does not use the `Result<>` in the standard library. 
Also, it is not mentioned to use the `serde_json::Result` namespace. 