### PR TITLE
Add slumber to app showcase

### DIFF
--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -127,6 +127,14 @@ A simple oscilloscope/vectorscope/spectroscope for your terminal
 
 ---
 
+## [`slumber`](https://github.com/LucasPickering/slumber)
+
+Terminal HTTP/REST client
+
+![slumber demo](https://media.githubusercontent.com/media/LucasPickering/slumber/master/static/demo.gif)
+
+---
+
 ## [`taskwarrior-tui`](https://github.com/kdheepak/taskwarrior-tui)
 
 A terminal user interface for taskwarrior


### PR DESCRIPTION
This adds my app [Slumber](https://github.com/LucasPickering/slumber) to the showcase. I didn't see any criteria listed for what apps qualify, but it's got ~200 stars now so I'm hoping it can go in. Let me know if I missed anything!

P.S. I know the gif is kinda fast, I'm working on that but since the link is just to the master branch on my repo, it won't need any updates to fix here.