### PR TITLE
docs: Hide async counter tutorial app from navbar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -93,11 +93,11 @@ export default defineConfig({
               collapsed: true,
               autogenerate: { directory: "tutorials/json-editor" },
             },
-            {
-              label: "Async Counter App",
-              collapsed: true,
-              autogenerate: { directory: "tutorials/counter-async-app" },
-            },
+            // {
+            //   label: "Async Counter App",
+            //   collapsed: true,
+            //   autogenerate: { directory: "tutorials/counter-async-app" },
+            // },
           ],
         },
         {

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -93,6 +93,8 @@ export default defineConfig({
               collapsed: true,
               autogenerate: { directory: "tutorials/json-editor" },
             },
+            // // This material is expected to be revised significantly.
+            // // Until then, it might be best to hide to avoid confusing new users.
             // {
             //   label: "Async Counter App",
             //   collapsed: true,


### PR DESCRIPTION
This PR removes the async counter tutorial material from the navbar. Until we have a more consistent set of tutorials, it might be best to hide the material so new users aren't confused. 

The links to the material will still be available if someone is interested in finding them.