### PR TITLE
use prettier 3.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "husky": "^9.0.11",
         "lint-staged": "^15.2.5",
         "playwright": "^1.44.1",
-        "prettier": "3.3.0",
+        "prettier": "3.2.5",
         "prettier-plugin-astro": "^0.14.0",
         "prettier-plugin-organize-imports": "^3.2.4",
         "prettier-plugin-svelte": "^3.2.3",
@@ -8492,9 +8492,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.0.tgz",
-      "integrity": "sha512-J9odKxERhCQ10OC2yb93583f6UnYutOeiV5i0zEDS7UGTdUt0u+y8erxl3lBKvwo/JHyyoEdXjwp4dke9oyZ/g==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
       "devOptional": true,
       "bin": {
         "prettier": "bin/prettier.cjs"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "husky": "^9.0.11",
     "lint-staged": "^15.2.5",
     "playwright": "^1.44.1",
-    "prettier": "3.3.0",
+    "prettier": "3.2.5",
     "prettier-plugin-astro": "^0.14.0",
     "prettier-plugin-organize-imports": "^3.2.4",
     "prettier-plugin-svelte": "^3.2.3",


### PR DESCRIPTION
Prettier 3.3.0 causes incorrect wrapping of lines with link definition references.

See https://github.com/prettier/prettier/issues/16351 for bug