### PR TITLE
Tweak TEA state diagram

### DIFF
--- a/src/content/docs/concepts/application-patterns/the-elm-architecture.md
+++ b/src/content/docs/concepts/application-patterns/the-elm-architecture.md
@@ -152,25 +152,27 @@ Here's a state transition diagram of the counter example from above:
 
 ```mermaid
 stateDiagram-v2
-    state Model {
-        counter : counter = 0
-        should_quit : should_quit = false
+    [*] --> Running
+    state Running {
+        state Increment <<choice>>
+        state Decrement <<choice>>
+        [*] --> Counting
+        Counting --> Increment: Increment
+        Increment --> Reset: if counter > 50 Reset
+        Increment --> Up: if counter <= 50
+        Up: counter += 1
+        Up --> Counting
+        Counting --> Decrement: Decrement
+        Decrement --> Down: if counter >= -50
+        Down: counter -= 1
+        Decrement --> Reset: if counter < -50 Reset
+
+        Reset: counter = 0
+        Reset --> Counting
+        Counting --> [*]: Quit
     }
-
-    Model --> Increment
-    Model --> Decrement
-    Model --> Reset
-    Model --> Quit
-
-    Increment --> Model: counter += 1
-    Increment --> Reset: if > 50
-
-    Decrement --> Model: counter -= 1
-    Decrement --> Reset: if < -50
-
-    Reset --> Model: counter = 0
-
-    Quit --> break: should_quit = true
+    Running --> Done
+    Done --> [*]
 ```
 
 While TEA doesn't use the Finite State Machine terminology or strictly enforce that paradigm,

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -44,6 +44,15 @@ svg[aria-roledescription="flowchart-v2"] path,
 svg[aria-roledescription="flowchart-v2"] .flowchart-link {
   stroke: currentColor !important;
 }
+svg[aria-roledescription="stateDiagram"] {
+  line-height: normal;
+}
+svg[aria-roledescription="stateDiagram"] line,
+svg[aria-roledescription="stateDiagram"] path,
+svg[aria-roledescription="stateDiagram"] circle {
+  stroke: currentColor !important;
+}
+
 marker#arrowhead path {
   fill: currentColor !important;
   stroke: currentColor !important;


### PR DESCRIPTION
Simplifies the diagram, fixes up the line height and colors.
Fixes https://github.com/ratatui-org/ratatui-website/issues/633

Rationale for changes:
- the messages aren't states - only Running and Done are
- within the running state, it's semi-reasonable to think of the state as counting, and the changes that happen as sort of implicit sub states oerhaps.