### PR TITLE
docs: fix typos & 0.28.0 breaking changes

### DIFF
--- a/code/counter-app-error-handling/src/tui.rs
+++ b/code/counter-app-error-handling/src/tui.rs
@@ -8,7 +8,7 @@ use ratatui::{
         execute,
         terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
     },
-    terminal::Terminal,
+    Terminal,
 };
 // ANCHOR_END: imports
 

--- a/src/content/docs/recipes/apps/color-eyre.md
+++ b/src/content/docs/recipes/apps/color-eyre.md
@@ -5,7 +5,11 @@ sidebar:
   label: color_eyre Error Hooks
 ---
 
-:::note[Source Code] Full source code is available at: <https://github.com/ratatui-org/ratatui-website/tree/main/code/how-to-color_eyre/>
+:::note[Source Code]
+
+Full source code is available at:
+<https://github.com/ratatui-org/ratatui-website/tree/main/code/how-to-color_eyre/>
+
 :::
 
 The [`color_eyre`] crate provides error report handlers for panics and errors. It displays the

--- a/src/content/docs/tutorials/counter-app/error-handling.md
+++ b/src/content/docs/tutorials/counter-app/error-handling.md
@@ -5,7 +5,11 @@ sidebar:
   label: Error Handling
 ---
 
-:::note[Source Code] Full source code is available at: <https://github.com/ratatui-org/ratatui-website/tree/main/code/counter-app-error-handling>.
+:::note[Source Code]
+
+Full source code is available at:
+<https://github.com/ratatui-org/ratatui-website/tree/main/code/counter-app-error-handling>.
+
 :::
 
 In the previous section, you created a [basic counter app](../basic-app/) that responds to the user


### PR DESCRIPTION
- Added spacing in markdown so that notes render correctly
![image](https://github.com/user-attachments/assets/bfa3a5ae-a922-4163-b0ba-a23f6d0f2425)

- Fixed import from now private `ratatui::terminal`