### PR TITLE
refactor: added links to stdio FAQ

### DIFF
--- a/src/content/docs/recipes/apps/terminal-and-event-handler.md
+++ b/src/content/docs/recipes/apps/terminal-and-event-handler.md
@@ -270,6 +270,12 @@ impl Drop for Tui {
 }
 ```
 
+:::note[Wondering why use `stderr`?]
+
+See the [FAQ](/faq/#should-i-use-stdout-or-stderr) for more details.
+
+:::
+
 Then you'll be able write code like this:
 
 ```rust

--- a/src/content/docs/templates/component/tui-rs.md
+++ b/src/content/docs/templates/component/tui-rs.md
@@ -53,6 +53,12 @@ about how terminal user interfaces work.
 We can reorganize the setup and teardown functions into an `enter()` and `exit()` methods on a `Tui`
 struct.
 
+:::note[Wondering whether to use `stdout` or `stderr`?]
+
+See the [FAQ](/faq/#should-i-use-stdout-or-stderr) for more details.
+
+:::
+
 ```rust
 use color_eyre::eyre::Result;
 use ratatui::crossterm::{


### PR DESCRIPTION
Fixes https://github.com/ratatui/ratatui/issues/1348.

I added some links to the stdout/stderr FAQ where relevant.

I tried adding one in `concepts` but didn't really find a suitable place for it.