### PR TITLE
Update user_input.md

### DIFF
--- a/src/content/docs/examples/Apps/user_input.md
+++ b/src/content/docs/examples/Apps/user_input.md
@@ -2,7 +2,7 @@
 title: User Input
 ---
 
-Demonstrates one approach to accepting user input. Source [user_input.rs](./user_input.rs).
+Demonstrates one approach to accepting user input. Source [user_input.rs](https://github.com/ratatui/ratatui/blob/main/examples/user_input.rs).
 
 :::caution Consider using [`tui-textarea`](https://crates.io/crates/tui-textarea) or
 [`tui-input`](https://crates.io/crates/tui-input) crates for more functional text entry UIs. :::


### PR DESCRIPTION
Fixing a broken link in the Ratatui webpage.
The link can be found here: https://ratatui.rs/examples/apps/user_input/ following the "Source user_input.rs." leads to a 404. 