### PR TITLE
docs: clarify defer in counter app tutorial

### DIFF
--- a/src/content/docs/tutorials/counter-app/basic-app.md
+++ b/src/content/docs/tutorials/counter-app/basic-app.md
@@ -60,7 +60,7 @@ A common pattern found in most Ratatui apps is that they:
 3. Restore the terminal back to its original state
 
 The `main` function sets up the terminal by calling the `ratatui::init` and `ratatui::restore`
-methods and then creates and runs the App (defined later). It defers evaluating the result of
+methods and then creates and runs the App (defined later). It defers the return of the result from
 calling `App::run()` until after the terminal is restored to ensure that any `Error` results will be
 displayed to the user after the application exits.
 

--- a/src/content/docs/tutorials/counter-app/basic-app.md
+++ b/src/content/docs/tutorials/counter-app/basic-app.md
@@ -61,8 +61,8 @@ A common pattern found in most Ratatui apps is that they:
 
 The `main` function sets up the terminal by calling the `ratatui::init` and `ratatui::restore`
 methods and then creates and runs the App (defined later). It defers propagating the return of
-`App::run()`'s result until after the terminal is restored to ensure that any `Error` results will be
-displayed to the user after the application exits.
+`App::run()`'s result until after the terminal is restored to ensure that any `Error` results will
+be displayed to the user after the application exits.
 
 Fill out the main function:
 

--- a/src/content/docs/tutorials/counter-app/basic-app.md
+++ b/src/content/docs/tutorials/counter-app/basic-app.md
@@ -60,7 +60,7 @@ A common pattern found in most Ratatui apps is that they:
 3. Restore the terminal back to its original state
 
 The `main` function sets up the terminal by calling the `ratatui::init` and `ratatui::restore`
-methods and then creates and runs the App (defined later). It defers the return of
+methods and then creates and runs the App (defined later). It defers propagating the return of
 `App::run()`'s result until after the terminal is restored to ensure that any `Error` results will be
 displayed to the user after the application exits.
 

--- a/src/content/docs/tutorials/counter-app/basic-app.md
+++ b/src/content/docs/tutorials/counter-app/basic-app.md
@@ -60,8 +60,8 @@ A common pattern found in most Ratatui apps is that they:
 3. Restore the terminal back to its original state
 
 The `main` function sets up the terminal by calling the `ratatui::init` and `ratatui::restore`
-methods and then creates and runs the App (defined later). It defers the return of the result from
-calling `App::run()` until after the terminal is restored to ensure that any `Error` results will be
+methods and then creates and runs the App (defined later). It defers the return of
+`App::run()`'s result until after the terminal is restored to ensure that any `Error` results will be
 displayed to the user after the application exits.
 
 Fill out the main function:


### PR DESCRIPTION
The docs suggested `App::run()` is deferred, but that's not quite right. The result is returned after the terminal is restored so errors are properly displayed. Updated the wording to make this clearer.