### PR TITLE
Remove deprecated assert_buffer_eq comment

### DIFF
--- a/code/tutorials/counter-app-basic/src/main.rs
+++ b/code/tutorials/counter-app-basic/src/main.rs
@@ -146,8 +146,6 @@ mod tests {
         expected.set_style(Rect::new(30, 3, 7, 1), key_style);
         expected.set_style(Rect::new(43, 3, 4, 1), key_style);
 
-        // note ratatui also has an assert_buffer_eq! macro that can be used to
-        // compare buffers and display the differences in a more readable way
         assert_eq!(buf, expected);
     }
     // ANCHOR_END: render test

--- a/code/tutorials/counter-app-error-handling/src/main.rs
+++ b/code/tutorials/counter-app-error-handling/src/main.rs
@@ -176,8 +176,6 @@ mod tests {
         expected.set_style(Rect::new(30, 3, 7, 1), key_style);
         expected.set_style(Rect::new(43, 3, 4, 1), key_style);
 
-        // note ratatui also has an assert_buffer_eq! macro that can be used to
-        // compare buffers and display the differences in a more readable way
         assert_eq!(buf, expected);
     }
     // ANCHOR_END: render test


### PR DESCRIPTION
assert_buffer_eq was deprecated in favor of assert_eq:
https://github.com/ratatui/ratatui/commit/2cfe82a47eb34baa25f474db7be364de7b95374a
