### PR TITLE
docs: Update better-panic/human_panic docs

### DIFF
--- a/src/content/docs/recipes/apps/better-panic.md
+++ b/src/content/docs/recipes/apps/better-panic.md
@@ -227,20 +227,21 @@ pub fn initialize_panic_handler() -> Result<()> {
     }
 
     let msg = format!("{}", panic_hook.panic_report(panic_info));
-    #[cfg(not(debug_assertions))]
+   #[cfg(not(debug_assertions))]
     {
-      eprintln!("{}", msg); // prints color-eyre stack trace to stderr
-      use human_panic::{handle_dump, print_msg, Metadata};
-      let meta = Metadata {
-        version: env!("CARGO_PKG_VERSION").into(),
-        name: env!("CARGO_PKG_NAME").into(),
-        authors: env!("CARGO_PKG_AUTHORS").replace(':', ", ").into(),
-        homepage: env!("CARGO_PKG_HOMEPAGE").into(),
-      };
+        eprintln!("{}", msg);
+        use human_panic::{handle_dump, print_msg, Metadata};
+        let author = format!("authored by {}", env!("CARGO_PKG_AUTHORS"));
+        let support = format!(
+            "You can open a support request at {}",
+            env!("CARGO_PKG_REPOSITORY")
+        );
+        let meta = Metadata::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
+            .authors(author)
+            .support(support);
 
-      let file_path = handle_dump(&meta, panic_info);
-      // prints human-panic message
-      print_msg(file_path, &meta).expect("human-panic: printing error message to console failed");
+        let file_path = handle_dump(&meta, panic_info);
+        print_msg(file_path, &meta).expect("human-panic: printing error message to console failed");
     }
     log::error!("Error: {}", strip_ansi_escapes::strip_str(msg));
 

--- a/src/content/docs/recipes/apps/better-panic.md
+++ b/src/content/docs/recipes/apps/better-panic.md
@@ -229,7 +229,7 @@ pub fn initialize_panic_handler() -> Result<()> {
     let msg = format!("{}", panic_hook.panic_report(panic_info));
     #[cfg(not(debug_assertions))]
     {
-        eprintln!("{}", msg);
+        eprintln!("{msg}");
         use human_panic::{handle_dump, print_msg, Metadata};
         let author = format!("authored by {}", env!("CARGO_PKG_AUTHORS"));
         let support = format!(

--- a/src/content/docs/recipes/apps/better-panic.md
+++ b/src/content/docs/recipes/apps/better-panic.md
@@ -227,7 +227,7 @@ pub fn initialize_panic_handler() -> Result<()> {
     }
 
     let msg = format!("{}", panic_hook.panic_report(panic_info));
-   #[cfg(not(debug_assertions))]
+    #[cfg(not(debug_assertions))]
     {
         eprintln!("{}", msg);
         use human_panic::{handle_dump, print_msg, Metadata};


### PR DESCRIPTION
The old code used the outdate version of configuring metadata, after facing the errors and searching for a fix i finally decided to read the docs and saw that the details for metatdata are now turned into function 
## Changes Made:
from :
```rs
{
      eprintln!("{}", msg); // prints color-eyre stack trace to stderr
      use human_panic::{handle_dump, print_msg, Metadata};
      let meta = Metadata {
        version: env!("CARGO_PKG_VERSION").into(),
        name: env!("CARGO_PKG_NAME").into(),
        authors: env!("CARGO_PKG_AUTHORS").replace(':', ", ").into(),
        homepage: env!("CARGO_PKG_HOMEPAGE").into(),
      };

      let file_path = handle_dump(&meta, panic_info);
      // prints human-panic message
      print_msg(file_path, &meta).expect("human-panic: printing error message to console failed");
      }
  ```

to :

```rs
#[cfg(not(debug_assertions))]
    {
        eprintln!("{}", msg);
        use human_panic::{handle_dump, print_msg, Metadata};
        let author = format!("authored by {}", env!("CARGO_PKG_AUTHORS"));
        let support = format!(
            "You can open a support request at {}",
            env!("CARGO_PKG_REPOSITORY")
        );
        let meta = Metadata::new(env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"))
            .authors(author)
            .support(support);

        let file_path = handle_dump(&meta, panic_info);
        print_msg(file_path, &meta).expect("human-panic: printing error message to console failed");
    }
```