### PR TITLE
🐛 Do not display `handle_key_event` test early

### DIFF
--- a/code/tutorials/counter-app-basic/src/main.rs
+++ b/code/tutorials/counter-app-basic/src/main.rs
@@ -59,6 +59,7 @@ impl App {
         Ok(())
     }
 
+    // ANCHOR: handle_key_event fn
     fn handle_key_event(&mut self, key_event: KeyEvent) {
         match key_event.code {
             KeyCode::Char('q') => self.exit(),
@@ -67,6 +68,7 @@ impl App {
             _ => {}
         }
     }
+    // ANCHOR_END: handle_key_event fn
 
     fn exit(&mut self) {
         self.exit = true;

--- a/src/content/docs/tutorials/counter-app/basic-app.md
+++ b/src/content/docs/tutorials/counter-app/basic-app.md
@@ -224,7 +224,7 @@ impl App {
 
     // -- snip --
 
-{{ #include @code/tutorials/counter-app-basic/src/main.rs:handle_key_event() }}
+{{ #include @code/tutorials/counter-app-basic/src/main.rs:handle_key_event fn }}
 }
 ```
 


### PR DESCRIPTION
Fixes #733.

The issue stems from _two_ functions in `src/main.rs` having the same name:
- `App.handle_key_event`
- `handle_key_event` in the test suit.

The fix disambiguates between these two `handle_key_event`s. 