### PR TITLE
Fix a broken link in the json editor tutorial

### DIFF
--- a/src/content/docs/tutorials/json-editor/ui.md
+++ b/src/content/docs/tutorials/json-editor/ui.md
@@ -82,8 +82,7 @@ terminals into account), and the application state.
 ```
 
 Before we proceed, let's implement a `centered_rect` helper function. This code is adapted from the
-[popup example](https://github.com/ratatui/ratatui/blob/main/ratatui/examples/popup.rs) found in the
-official repo.
+[popup example](https://ratatui.rs/examples/apps/popup/).
 
 ```rust
 {{#include @code/tutorials/json-editor/src/ui.rs:centered_rect}}

--- a/src/content/docs/tutorials/json-editor/ui.md
+++ b/src/content/docs/tutorials/json-editor/ui.md
@@ -82,7 +82,7 @@ terminals into account), and the application state.
 ```
 
 Before we proceed, let's implement a `centered_rect` helper function. This code is adapted from the
-[popup example](https://github.com/ratatui/ratatui/blob/main/examples/popup.rs) found in the
+[popup example](https://github.com/ratatui/ratatui/blob/main/ratatui/examples/popup.rs) found in the
 official repo.
 
 ```rust


### PR DESCRIPTION
In the UI section of the JSON editor tutorial there's a broken link to the now moved [popup example](https://github.com/ratatui/ratatui/blob/main/ratatui/examples/popup.rs)