### PR TITLE
Add warning for import conflict with crossterm.

### DIFF
--- a/src/content/docs/tutorials/counter-app/basic-app.md
+++ b/src/content/docs/tutorials/counter-app/basic-app.md
@@ -47,7 +47,8 @@ welcome to use explicit imports if that is your preferred style.
 :::caution
 
 Some editors remove unused imports automatically, so if you run into errors about missing types,
-etc. make sure these are in place.
+etc. make sure these are in place. and double-check that shared imports like `Stylize` come from 
+ratatui and not crossterm to avoid conflicts.
 
 :::
 


### PR DESCRIPTION
Adds a caution in the very project regarding import conflicts with `crossterm` lib for import conflict, this confused me and took me a while to figure as it was such a minute thing to miss out. 


(other than hello-world as it did not made use of crossterm imports)