### PR TITLE
fix apps previews for bottom, rucola and scope-tui

### DIFF
--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -27,7 +27,7 @@ IP/hostname
 
 A customizable cross-platform graphical process/system monitor for the terminal
 
-![bottom demo](https://github.com/ClementTsang/bottom/blob/master/assets/demo.gif?raw=true)
+![bottom demo](https://github.com/ClementTsang/bottom/blob/main/assets/demo.gif?raw=true)
 
 ---
 

--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -123,7 +123,7 @@ oha is a tiny program that sends some load to a web application and show realtim
 
 An application to manage markdown notes from your terminal and compile them to HTML
 
-![rucola demo](https://github.com/Linus-Mussmaecher/rucola/blob/main/readme-images/readme-image-select.png)
+![rucola demo](https://github.com/Linus-Mussmaecher/rucola/blob/main/readme-images/readme-image-select.png?raw=true)
 
 ---
 
@@ -131,7 +131,7 @@ An application to manage markdown notes from your terminal and compile them to H
 
 A simple oscilloscope/vectorscope/spectroscope for your terminal
 
-![scope-tui demo](https://camo.githubusercontent.com/144d96875a367bd55d8cc2343da2479aefea9925106b71d9e73aa9bebc57c33f/68747470733a2f2f63646e2e616c656d692e6465762f73636f70652d7475692d776964652e706e67)
+![scope-tui demo](https://camo.githubusercontent.com/4b11674184b07eebd6bc386c38c9cce1a7a70ae82733b44cd977c8ab85c5a691/68747470733a2f2f63646e2e616c656d692e6465762f73636f70652d7475692d776964652e706e67)
 
 ---
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c2b30e65-7dcb-4c82-aabb-f2bb0ad550d9)

![CleanShot 2024-12-06 at 12 08 55@2x](https://github.com/user-attachments/assets/a37483a3-78ff-4510-ad0d-524fc546d96d)

↓

<img width="1037" alt="image" src="https://github.com/user-attachments/assets/9fce6d66-7b45-47e7-a15f-3a3d1e54caf7">

![CleanShot 2024-12-06 at 12 08 22@2x](https://github.com/user-attachments/assets/bcc7a8eb-ec01-4957-bc80-8a8290b594d2)
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/0a5a5679-e81d-439d-8cee-515fa341098d">


bottom: they changed base branch from master to main and GitHub redirect don't handle raw=true links
rucola: was not pointing to raw file
scope-tui: it changed url