### PR TITLE
chore: Fix typo in backends index.md

### DIFF
--- a/src/content/docs/concepts/backends/index.md
+++ b/src/content/docs/concepts/backends/index.md
@@ -6,7 +6,7 @@ sidebar:
 
 Ratatui interfaces with the terminal emulator through a backend. These libraries enable Ratatui via
 the [`Terminal`] type to draw styled text to the screen, manipulate the cursor, and interrogate
-properties of the terminal such as the console or window size. You application will generally also
+properties of the terminal such as the console or window size. Your application will generally also
 use the backend directly to capture keyboard, mouse and window events, and enable raw mode and the
 alternate screen.
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/24ae98e1-5b02-427d-971d-592a40c8cbf6)
