### PR TITLE
Fix broken formatting of 'note' in installation guide

### DIFF
--- a/src/content/docs/installation/index.md
+++ b/src/content/docs/installation/index.md
@@ -41,7 +41,7 @@ By default, `ratatui` enables the `crossterm` feature, but it's possible to alte
 `termion`, or `termwiz` instead by enabling the appropriate feature and disabling the default
 features. See [Backend] for more information.
 
-::: note
+:::note
 
 Before Ratatui 0.27.0, it was necessary to import a backend crate that matched the backend feature.
 In 0.27.0 Ratatui now exports the backend crates at the root to make it easier to ensure a matching


### PR DESCRIPTION
While reading the installation guide, I found what seems to be a typo / formatting error.
https://ratatui.rs/installation/

Before:
![Bildschirmfoto_2025-04-06_14-39-04](https://github.com/user-attachments/assets/aa805041-a706-472e-8b07-f9146c31c434)

After: (I can't build it locally yet, but the syntax seems obvious enough, I hope I'm not entirely wrong.)