### PR TITLE
Remove the usage of `set_var`

### DIFF
--- a/code/templates/async-template-counter/src/components/fps.rs
+++ b/code/templates/async-template-counter/src/components/fps.rs
@@ -4,6 +4,7 @@ use color_eyre::eyre::Result;
 use ratatui::{
   layout::{Alignment, Constraint, Direction, Layout, Rect},
   style::Stylize,
+  text::Line,
   widgets::Block,
   Frame,
 };

--- a/code/templates/async-template-counter/src/utils.rs
+++ b/code/templates/async-template-counter/src/utils.rs
@@ -98,7 +98,7 @@ pub fn initialize_logging() -> Result<()> {
   std::fs::create_dir_all(directory.clone())?;
   let log_path = directory.join(LOG_FILE.clone());
   let log_file = std::fs::File::create(log_path)?;
-  let filter_string = std::env::var("RUST_LOG")
+  let log_filter = std::env::var("RUST_LOG")
     .or_else(|_| std::env::var(LOG_ENV.clone()))
     .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME")));
   let file_subscriber = tracing_subscriber::fmt::layer()
@@ -107,7 +107,7 @@ pub fn initialize_logging() -> Result<()> {
     .with_writer(log_file)
     .with_target(false)
     .with_ansi(false)
-    .with_filter(tracing_subscriber::filter::EnvFilter::builder().parse_lossy(filter_string));
+    .with_filter(tracing_subscriber::filter::EnvFilter::builder().parse_lossy(log_filter));
   tracing_subscriber::registry().with(file_subscriber).with(ErrorLayer::default()).init();
   Ok(())
 }

--- a/code/templates/async-template-counter/src/utils.rs
+++ b/code/templates/async-template-counter/src/utils.rs
@@ -98,21 +98,16 @@ pub fn initialize_logging() -> Result<()> {
   std::fs::create_dir_all(directory.clone())?;
   let log_path = directory.join(LOG_FILE.clone());
   let log_file = std::fs::File::create(log_path)?;
-  unsafe {
-    std::env::set_var(
-      "RUST_LOG",
-      std::env::var("RUST_LOG")
-        .or_else(|_| std::env::var(LOG_ENV.clone()))
-        .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME"))),
-    )
-  };
+  let filter_string = std::env::var("RUST_LOG")
+    .or_else(|_| std::env::var(LOG_ENV.clone()))
+    .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME")));
   let file_subscriber = tracing_subscriber::fmt::layer()
     .with_file(true)
     .with_line_number(true)
     .with_writer(log_file)
     .with_target(false)
     .with_ansi(false)
-    .with_filter(tracing_subscriber::filter::EnvFilter::from_default_env());
+    .with_filter(tracing_subscriber::filter::EnvFilter::builder().parse_lossy(filter_string));
   tracing_subscriber::registry().with(file_subscriber).with(ErrorLayer::default()).init();
   Ok(())
 }

--- a/code/templates/async-template-counter/src/utils.rs
+++ b/code/templates/async-template-counter/src/utils.rs
@@ -98,12 +98,14 @@ pub fn initialize_logging() -> Result<()> {
   std::fs::create_dir_all(directory.clone())?;
   let log_path = directory.join(LOG_FILE.clone());
   let log_file = std::fs::File::create(log_path)?;
-  std::env::set_var(
-    "RUST_LOG",
-    std::env::var("RUST_LOG")
-      .or_else(|_| std::env::var(LOG_ENV.clone()))
-      .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME"))),
-  );
+  unsafe {
+    std::env::set_var(
+      "RUST_LOG",
+      std::env::var("RUST_LOG")
+        .or_else(|_| std::env::var(LOG_ENV.clone()))
+        .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME"))),
+    )
+  };
   let file_subscriber = tracing_subscriber::fmt::layer()
     .with_file(true)
     .with_line_number(true)

--- a/src/content/docs/recipes/apps/log-with-tracing.md
+++ b/src/content/docs/recipes/apps/log-with-tracing.md
@@ -53,12 +53,14 @@ pub fn initialize_logging() -> Result<()> {
   std::fs::create_dir_all(directory.clone())?;
   let log_path = directory.join(LOG_FILE.clone());
   let log_file = std::fs::File::create(log_path)?;
-  std::env::set_var(
-    "RUST_LOG",
-    std::env::var("RUST_LOG")
+  unsafe {
+    std::env::set_var(
+      "RUST_LOG",
+      std::env::var("RUST_LOG")
       .or_else(|_| std::env::var(LOG_ENV.clone()))
       .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME"))),
-  );
+    )
+  };
   let file_subscriber = tracing_subscriber::fmt::layer()
     .with_file(true)
     .with_line_number(true)

--- a/src/content/docs/recipes/apps/log-with-tracing.md
+++ b/src/content/docs/recipes/apps/log-with-tracing.md
@@ -53,21 +53,16 @@ pub fn initialize_logging() -> Result<()> {
   std::fs::create_dir_all(directory.clone())?;
   let log_path = directory.join(LOG_FILE.clone());
   let log_file = std::fs::File::create(log_path)?;
-  unsafe {
-    std::env::set_var(
-      "RUST_LOG",
-      std::env::var("RUST_LOG")
-        .or_else(|_| std::env::var(LOG_ENV.clone()))
-        .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME"))),
-    )
-  };
+  let filter_string = std::env::var("RUST_LOG")
+    .or_else(|_| std::env::var(LOG_ENV.clone()))
+    .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME")));
   let file_subscriber = tracing_subscriber::fmt::layer()
     .with_file(true)
     .with_line_number(true)
     .with_writer(log_file)
     .with_target(false)
     .with_ansi(false)
-    .with_filter(tracing_subscriber::filter::EnvFilter::from_default_env());
+    .with_filter(tracing_subscriber::filter::EnvFilter::builder().parse_lossy(filter_string));
   tracing_subscriber::registry().with(file_subscriber).with(ErrorLayer::default()).init();
   Ok(())
 }

--- a/src/content/docs/recipes/apps/log-with-tracing.md
+++ b/src/content/docs/recipes/apps/log-with-tracing.md
@@ -53,7 +53,7 @@ pub fn initialize_logging() -> Result<()> {
   std::fs::create_dir_all(directory.clone())?;
   let log_path = directory.join(LOG_FILE.clone());
   let log_file = std::fs::File::create(log_path)?;
-  let filter_string = std::env::var("RUST_LOG")
+  let log_filter = std::env::var("RUST_LOG")
     .or_else(|_| std::env::var(LOG_ENV.clone()))
     .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME")));
   let file_subscriber = tracing_subscriber::fmt::layer()
@@ -62,7 +62,7 @@ pub fn initialize_logging() -> Result<()> {
     .with_writer(log_file)
     .with_target(false)
     .with_ansi(false)
-    .with_filter(tracing_subscriber::filter::EnvFilter::builder().parse_lossy(filter_string));
+    .with_filter(tracing_subscriber::filter::EnvFilter::builder().parse_lossy(log_filter));
   tracing_subscriber::registry().with(file_subscriber).with(ErrorLayer::default()).init();
   Ok(())
 }

--- a/src/content/docs/recipes/apps/log-with-tracing.md
+++ b/src/content/docs/recipes/apps/log-with-tracing.md
@@ -57,8 +57,8 @@ pub fn initialize_logging() -> Result<()> {
     std::env::set_var(
       "RUST_LOG",
       std::env::var("RUST_LOG")
-      .or_else(|_| std::env::var(LOG_ENV.clone()))
-      .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME"))),
+        .or_else(|_| std::env::var(LOG_ENV.clone()))
+        .unwrap_or_else(|_| format!("{}=info", env!("CARGO_CRATE_NAME"))),
     )
   };
   let file_subscriber = tracing_subscriber::fmt::layer()


### PR DESCRIPTION
`std::env::set_var` is marked as unsafe starting in the 2024 Edition.

https://doc.rust-lang.org/edition-guide/rust-2024/newly-unsafe-functions.html