### PR TITLE
Add debug-widget-state article

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,9 +440,9 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55146f5e46f237f7423d74111267d4597b59b0dad0ffaf7303bce9945d843ad5"
+checksum = "e5920befb47832a6d61ee3a3a846565cfa39b331331e68a3b1d1116630f2f26d"
 dependencies = [
  "backtrace",
  "color-spantrace",
@@ -455,9 +455,9 @@ dependencies = [
 
 [[package]]
 name = "color-spantrace"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6be1b2a7e382e2b98b43b2adcca6bb0e465af0bdd38123873ae61eb17a72c2"
+checksum = "b8b88ea9df13354b55bc7234ebcce36e6ef896aca2e42a15de9e10edce01b427"
 dependencies = [
  "once_cell",
  "owo-colors",
@@ -1256,6 +1256,15 @@ name = "how-to-color_eyre"
 version = "0.0.0"
 dependencies = [
  "color-eyre",
+ "ratatui",
+]
+
+[[package]]
+name = "how-to-debug-widget-state"
+version = "0.0.0"
+dependencies = [
+ "color-eyre",
+ "crossterm",
  "ratatui",
 ]
 
@@ -2096,9 +2105,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "palette"

--- a/code/recipes/how-to-debug-widget-state/Cargo.toml
+++ b/code/recipes/how-to-debug-widget-state/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "how-to-debug-widget-state"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+[dependencies]
+color-eyre = "0.6.5"
+crossterm = "0.28.1"
+ratatui = "0.29.0"

--- a/code/recipes/how-to-debug-widget-state/src/main.rs
+++ b/code/recipes/how-to-debug-widget-state/src/main.rs
@@ -1,0 +1,69 @@
+//! Demonstrates how to debug widget state in a Rust application by showing a debug view of the state.
+
+use crossterm::event::{self, Event, KeyCode, KeyEventKind};
+use ratatui::{
+    buffer::Buffer,
+    layout::{Constraint, Layout, Rect},
+    text::Text,
+    widgets::Widget,
+    DefaultTerminal, Frame,
+};
+
+fn main() -> color_eyre::Result<()> {
+    color_eyre::install()?;
+    let terminal = ratatui::init();
+    let result = run(terminal);
+    ratatui::restore();
+    result
+}
+
+#[derive(Debug, Default)]
+struct AppState {
+    show_debug: bool,
+    form: Form,
+}
+
+#[derive(Debug, Default)]
+struct Form {
+    name: String,
+    age: u8,
+}
+
+impl Widget for &Form {
+    fn render(self, area: Rect, buf: &mut Buffer) {
+        let [name, age] = Layout::vertical([Constraint::Length(1); 2]).areas(area);
+        format!("Name: {}", self.name).render(name, buf);
+        format!("Age: {}", self.age).render(age, buf);
+    }
+}
+
+fn run(mut terminal: DefaultTerminal) -> color_eyre::Result<()> {
+    let mut state = AppState::default();
+    loop {
+        terminal.draw(|frame| render(frame, &state))?;
+        match event::read()? {
+            Event::Key(key) if key.kind == KeyEventKind::Press => {
+                match key.code {
+                    KeyCode::Char('q') => return Ok(()),
+                    KeyCode::Char('d') => state.show_debug = !state.show_debug, // Toggle debug view
+                    KeyCode::Char('n') => state.form.name.push('a'), // Simulate user input
+                    KeyCode::Char('a') => state.form.age += 1,       // Simulate user input
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn render(frame: &mut Frame, state: &AppState) {
+    let debug_width = u16::from(state.show_debug);
+    let [main, debug] = Layout::horizontal([Constraint::Fill(1), Constraint::Fill(debug_width)])
+        .areas(frame.area());
+    frame.render_widget(&state.form, main);
+
+    if state.show_debug {
+        let debug_text = Text::from(format!("state: {:#?}", state));
+        frame.render_widget(debug_text, debug);
+    }
+}

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -19,7 +19,8 @@ hero:
       variant: secondary
 banner:
   content:
-    Join the <a href="https://github.com/ratatui/ratatui/discussions/1886">Rat in the Wild Challenge</a> — build the craziest Ratatui app and win some cheese! 🧀
+    Join the <a href="https://github.com/ratatui/ratatui/discussions/1886">Rat in the Wild
+    Challenge</a> — build the craziest Ratatui app and win some cheese! 🧀
 ---
 
 import { Card, CardGrid } from "@astrojs/starlight/components";

--- a/src/content/docs/recipes/testing/debug-widget-state.md
+++ b/src/content/docs/recipes/testing/debug-widget-state.md
@@ -17,8 +17,8 @@ development and debugging purposes.
 
 The following code shows how you might implement this for some simple form's state. More advanced
 applications may want to have more sophisticated debug views, but the principle remains the same.
-The applicaiton state has a `show_debug` field that can be toggled on and off, and the and the
-`render` function allocates some space to render the debug information when `show_debug` is true.
+The app state has a `show_debug` field that can be toggled on and off, and the and the `render`
+function allocates some space to render the debug information when `show_debug` is true.
 
 ```rust collapse={3-19}
 {{ #include @code/recipes/how-to-debug-widget-state/src/main.rs }}

--- a/src/content/docs/recipes/testing/debug-widget-state.md
+++ b/src/content/docs/recipes/testing/debug-widget-state.md
@@ -1,0 +1,27 @@
+---
+title: Debugging Widget State
+sidebar:
+  order: 2
+---
+
+Debugging widget state in a Ratatui application can be challenging as the Ratatui takes over the
+terminal, so your usual debugging tools like `println!` and `dbg!` won't work as expected. However,
+you can still debug your widget state effectively by writing logs to a file, or using [tui-logger].
+
+Sometimes though, you might want to inspect the state of a widget or some application value directly
+in your terminal. You can do this easily, by rendering the debug text of the widget or value
+somewhere useful and providing a way to toggle it on and off. This is especially useful for
+development and debugging purposes.
+
+![Example](./debug-widget-state.png)
+
+The following code shows how you might implement this for some simple form's state. More advanced
+applications may want to have more sophisticated debug views, but the principle remains the same.
+The applicaiton state has a `show_debug` field that can be toggled on and off, and the and the
+`render` function allocates some space to render the debug information when `show_debug` is true.
+
+```rust collapse={3-19}
+{{ #include @code/recipes/how-to-debug-widget-state/src/main.rs }}
+```
+
+[tui-logger]: https://crates.io/crates/tui-logger

--- a/src/content/docs/recipes/testing/debug-widget-state.png
+++ b/src/content/docs/recipes/testing/debug-widget-state.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44077d494d072832cf950ae1b6b6e42a439ed7385fb809ba88432b3568adadec
+size 33084

--- a/src/content/docs/recipes/testing/index.md
+++ b/src/content/docs/recipes/testing/index.md
@@ -1,0 +1,8 @@
+---
+title: Testing Apps
+sidebar:
+  order: 0
+---
+
+- [Testing with insta snapshots](./snapshots/)
+- [Debugging Widget State](./debug-widget-state/)


### PR DESCRIPTION
https://ratatui.rs/recipes/testing/debug-widget-state/

Answers https://discord.com/channels/442252698964721669/448238009733742612/1380979222486712371 

>  i'm using ratatui so i can't use println!() for debugging since it takes over stdout, is there a quick way to get output somehow without adding a large library like log4rs? i only really need it for quick debugging

