### PR TITLE
fix: utils.rs section link

### DIFF
--- a/src/content/docs/templates/component/main-rs.md
+++ b/src/content/docs/templates/component/main-rs.md
@@ -23,4 +23,4 @@ but in my opinion, essential for any Terminal User Interface (TUI) program:
 - Logging
 - Panic Handler
 
-These are described in more detail in the [`utils.rs` section](./08-structure.md).
+These are described in more detail in the [`utils.rs` section](./utils-rs.md).


### PR DESCRIPTION
currently on click to `utils.rs section` will redirect to 404 page, I fixed it, however I'm not sure if I put correct link