### PR TITLE
chore: ignore badge.svg in typos check

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -9,3 +9,6 @@ iterm = "iTerm2"
 extend-ignore-re = [
   "\\[[[:xdigit:]]{7}\\]\\(https://github.com/ratatui/ratatui/commit/[[:xdigit:]]{40}\\)",
 ]
+
+[files]
+extend-exclude = ["public/built-with-ratatui/badge.svg"]


### PR DESCRIPTION
ci was failing due to base64-encoded SVG; ignore this file in typos
