### PR TITLE
fix: update broken links to recipe sources

### DIFF
--- a/src/content/docs/recipes/layout/center-a-widget.md
+++ b/src/content/docs/recipes/layout/center-a-widget.md
@@ -79,7 +79,7 @@ text using the [textwrap crate] and then using the line count to work out where 
 :::
 
 Full code for this recipe is available in the website repo at:
-<https://github.com/ratatui/ratatui-website/blob/main/code/recipes/src/layout.rs>
+<https://github.com/ratatui/ratatui-website/blob/main/code/recipes/how-to-misc/src/layout.rs>
 
 ## See also
 

--- a/src/content/docs/recipes/layout/collapse-borders.md
+++ b/src/content/docs/recipes/layout/collapse-borders.md
@@ -80,7 +80,7 @@ If this sounds too complex, we're looking for some help to make this easier in
 :::
 
 The full code for this example is available at
-<https://github.com/ratatui/ratatui-website/blob/main/code/how-to-collapse-borders>
+<https://github.com/ratatui/ratatui-website/blob/main/code/recipes/how-to-collapse-borders>
 
 ```rust collapsed title="collapse-borders.rs"
 {{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs}}


### PR DESCRIPTION
While updating docs about border collapsing, I found out these links don't work.