### PR TITLE
docs: update collapse borders recipe for Ratatui 0.30

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -256,9 +256,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
 ]
@@ -405,7 +405,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
  "unicase",
  "unicode-width 0.2.0",
@@ -487,13 +487,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "config"
 version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "595aae20e65c3be792d05818e8c63025294ac3cb7e200f11459063a352a6ef80"
 dependencies = [
  "async-trait",
- "convert_case",
+ "convert_case 0.6.0",
  "json5",
  "pathdiff",
  "ron",
@@ -547,6 +561,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,8 +589,8 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 name = "counter-app-basic"
 version = "0.0.0"
 dependencies = [
- "crossterm",
- "ratatui",
+ "crossterm 0.28.1",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -575,7 +598,7 @@ name = "counter-app-error-handling"
 version = "0.0.0"
 dependencies = [
  "color-eyre",
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -663,13 +686,31 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "crossterm_winapi",
  "futures-core",
  "mio",
  "parking_lot",
- "rustix",
+ "rustix 0.38.42",
  "serde",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossterm_winapi",
+ "derive_more",
+ "document-features",
+ "mio",
+ "parking_lot",
+ "rustix 1.0.7",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -730,7 +771,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.11.1",
+ "strsim",
  "syn 2.0.90",
 ]
 
@@ -800,6 +841,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093242cf7570c207c83073cf82f79706fe7b8317e98620a47d5be7c3d8497678"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
+dependencies = [
+ "convert_case 0.7.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -889,6 +951,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
 dependencies = [
  "const-random",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1226,8 +1297,8 @@ name = "hello-ratatui"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
- "crossterm",
- "ratatui",
+ "crossterm 0.28.1",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -1247,8 +1318,7 @@ name = "how-to-collapse-borders"
 version = "0.0.0"
 dependencies = [
  "color-eyre",
- "crossterm",
- "ratatui",
+ "ratatui 0.30.0-alpha.5",
 ]
 
 [[package]]
@@ -1256,7 +1326,7 @@ name = "how-to-color_eyre"
 version = "0.0.0"
 dependencies = [
  "color-eyre",
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -1264,8 +1334,8 @@ name = "how-to-debug-widget-state"
 version = "0.0.0"
 dependencies = [
  "color-eyre",
- "crossterm",
- "ratatui",
+ "crossterm 0.28.1",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -1275,21 +1345,21 @@ dependencies = [
  "color-eyre",
  "derive_setters",
  "lipsum",
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
 name = "how-to-panic-hooks"
 version = "0.0.0"
 dependencies = [
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
 name = "how-to-spawn-vim"
 version = "0.0.0"
 dependencies = [
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -1696,7 +1766,7 @@ dependencies = [
 name = "json-editor"
 version = "0.0.0"
 dependencies = [
- "ratatui",
+ "ratatui 0.29.0",
  "serde",
  "serde_json",
 ]
@@ -1725,6 +1795,16 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "kasuari"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d9e0d6a8bf886abccc1cbcac7d74f9000ae5882aedc4a9042188bbc9cd4487"
+dependencies = [
+ "hashbrown 0.15.2",
+ "thiserror 2.0.8",
 ]
 
 [[package]]
@@ -1760,9 +1840,18 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "line-clipping"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51a1679740111eb63b7b4cb3c97b1d5d9f82e142292a25edcfdb4120a48b3880"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -1770,6 +1859,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "lipsum"
@@ -1786,6 +1881,12 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "lock_api"
@@ -1808,6 +1909,15 @@ name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.2",
+]
+
+[[package]]
+name = "lru"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f8cc7106155f10bdf99a6f379688f543ad6596a415375b36a59a054ceda1198"
 dependencies = [
  "hashbrown 0.15.2",
 ]
@@ -1907,7 +2017,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -1959,6 +2069,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2388,7 +2509,7 @@ dependencies = [
 name = "quickstart-ratatui"
 version = "0.1.0"
 dependencies = [
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -2590,22 +2711,56 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "cassowary",
- "compact_str",
- "crossterm",
+ "compact_str 0.8.0",
+ "crossterm 0.28.1",
  "indoc",
  "instability",
  "itertools 0.13.0",
- "lru",
+ "lru 0.12.5",
  "paste",
  "serde",
  "strum 0.26.3",
  "termion",
- "termwiz",
+ "termwiz 0.22.0",
  "time",
  "unicode-segmentation",
- "unicode-truncate",
+ "unicode-truncate 1.1.0",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "ratatui"
+version = "0.30.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71365e96fb8f1350c02908e788815c5a57c0c1f557673b274a94edee7a4fe001"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0-alpha.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f836b2eac888da74162b680a8facdbe784ae73df3b0f711eef74bb90a7477f78"
+dependencies = [
+ "bitflags 2.9.1",
+ "compact_str 0.9.0",
+ "hashbrown 0.15.2",
+ "indoc",
+ "itertools 0.14.0",
+ "kasuari",
+ "lru 0.14.0",
+ "strum 0.27.1",
+ "thiserror 2.0.8",
+ "unicode-segmentation",
+ "unicode-truncate 2.0.0",
  "unicode-width 0.2.0",
 ]
 
@@ -2614,7 +2769,7 @@ name = "ratatui-counter-app"
 version = "0.1.0"
 dependencies = [
  "color-eyre",
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -2625,7 +2780,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "config",
- "crossterm",
+ "crossterm 0.28.1",
  "derive_deref",
  "directories",
  "futures",
@@ -2635,7 +2790,7 @@ dependencies = [
  "libc",
  "log",
  "pretty_assertions",
- "ratatui",
+ "ratatui 0.29.0",
  "serde",
  "serde_json",
  "signal-hook",
@@ -2648,6 +2803,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-crossterm"
+version = "0.1.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f4a90548bf8ed759d226d621d73561110db23aee7b7dc4e12c39ac7132062f"
+dependencies = [
+ "crossterm 0.29.0",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
 name = "ratatui-examples"
 version = "0.0.0"
 dependencies = [
@@ -2656,7 +2822,7 @@ dependencies = [
  "better-panic",
  "color-eyre",
  "criterion",
- "crossterm",
+ "crossterm 0.28.1",
  "derive_builder",
  "fakeit",
  "font8x8",
@@ -2668,7 +2834,7 @@ dependencies = [
  "pretty_assertions",
  "rand 0.9.0",
  "rand_chacha 0.9.0",
- "ratatui",
+ "ratatui 0.29.0",
  "rstest",
  "serde_json",
  "strum 0.27.1",
@@ -2681,23 +2847,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui-macros"
+version = "0.7.0-alpha.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f4c660248a5a9edf95698cf33dc36a82ae48a918594480cdada340d81584e0b"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
 name = "ratatui-stopwatch-app"
 version = "0.0.0"
 dependencies = [
  "color-eyre",
- "crossterm",
+ "crossterm 0.28.1",
  "directories",
  "futures",
  "human-panic",
  "itertools 0.14.0",
  "libc",
  "log",
- "ratatui",
+ "ratatui 0.29.0",
  "strip-ansi-escapes",
  "strum 0.27.1",
  "tokio",
  "tokio-util",
  "tui-big-text",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbb5d7645e56f06ead2a49a72b9cc05022f0b215ec7cdf39d37ed94e9a73d69"
+dependencies = [
+ "ratatui-core",
+ "termwiz 0.23.0",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0-alpha.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388428527811be6da3e23157d951308d9eae4ce1b4d1d545a55673bbcdfb7326"
+dependencies = [
+ "bitflags 2.9.1",
+ "hashbrown 0.15.2",
+ "indoc",
+ "instability",
+ "itertools 0.14.0",
+ "line-clipping",
+ "ratatui-core",
+ "strum 0.27.1",
+ "time",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -2733,7 +2938,7 @@ dependencies = [
 name = "recipes"
 version = "0.0.0"
 dependencies = [
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -2742,7 +2947,7 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -2844,7 +3049,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "serde",
  "serde_derive",
 ]
@@ -2917,10 +3122,23 @@ version = "0.38.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.14",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -3019,7 +3237,7 @@ version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3281,12 +3499,6 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
@@ -3389,7 +3601,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "once_cell",
- "rustix",
+ "rustix 0.38.42",
  "windows-sys 0.59.0",
 ]
 
@@ -3399,7 +3611,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix",
+ "rustix 0.38.42",
  "windows-sys 0.59.0",
 ]
 
@@ -3410,6 +3622,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "666cd3a6681775d22b200409aad3b089c5b99fb11ecdd8a204d9d62f8148498f"
 dependencies = [
  "dirs",
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
  "fnv",
  "nom",
  "phf",
@@ -3445,7 +3669,7 @@ checksum = "5a75313e21da5d4406ea31402035b3b97aa74c04356bdfafa5d1043ab4e551d1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
@@ -3456,7 +3680,7 @@ dependencies = [
  "log",
  "memmem",
  "nix 0.26.4",
- "num-derive",
+ "num-derive 0.3.3",
  "num-traits",
  "ordered-float",
  "pest",
@@ -3467,7 +3691,49 @@ dependencies = [
  "signal-hook",
  "siphasher",
  "tempfile",
- "terminfo",
+ "terminfo 0.8.0",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed32af792ae81937cb8640b03eaef737408e5c8feee47b35e8b80c49bcb64524"
+dependencies = [
+ "anyhow",
+ "base64 0.21.7",
+ "bitflags 2.9.1",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix 0.28.0",
+ "num-derive 0.4.2",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo 0.9.0",
  "termios",
  "thiserror 1.0.69",
  "ucd-trie",
@@ -3713,7 +3979,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "403fa3b783d4b626a8ad51d766ab03cb6d2dbfc46b1c5d4448395e6628dc9697"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "bytes",
  "futures-util",
  "http",
@@ -3844,7 +4110,7 @@ dependencies = [
  "derive_builder",
  "font8x8",
  "itertools 0.14.0",
- "ratatui",
+ "ratatui 0.29.0",
 ]
 
 [[package]]
@@ -3892,6 +4158,17 @@ dependencies = [
  "itertools 0.13.0",
  "unicode-segmentation",
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-truncate"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fbf03860ff438702f3910ca5f28f8dac63c1c11e7efb5012b8b175493606330"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4138,22 +4415,22 @@ dependencies = [
 
 [[package]]
 name = "wezterm-dynamic"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb128bacfa86734e07681fb6068e34c144698e84ee022d6e009145d1abb77b5"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
 dependencies = [
  "log",
  "ordered-float",
- "strsim 0.10.0",
+ "strsim",
  "thiserror 1.0.69",
  "wezterm-dynamic-derive",
 ]
 
 [[package]]
 name = "wezterm-dynamic-derive"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c9f5ef318442d07b3d071f9f43ea40b80992f87faee14bb4d017b6991c307f0"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4179,7 +4456,7 @@ dependencies = [
  "clap",
  "color-eyre",
  "lipsum",
- "ratatui",
+ "ratatui 0.29.0",
  "textwrap",
  "time",
 ]
@@ -4330,7 +4607,7 @@ version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/code/recipes/how-to-collapse-borders/Cargo.toml
+++ b/code/recipes/how-to-collapse-borders/Cargo.toml
@@ -15,5 +15,4 @@ publish.workspace = true
 
 [dependencies]
 color-eyre = "0.6.3"
-crossterm = "0.28.1"
-ratatui = "0.29.0"
+ratatui = "0.30.0-alpha.5"

--- a/code/recipes/how-to-collapse-borders/src/bin/problem.rs
+++ b/code/recipes/how-to-collapse-borders/src/bin/problem.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 use color_eyre::Result;
-use crossterm::event::{self, Event};
+use ratatui::crossterm::event::{self, Event};
 use ratatui::{
     layout::{Constraint, Layout},
     widgets::Block,

--- a/code/recipes/how-to-collapse-borders/src/bin/solution.rs
+++ b/code/recipes/how-to-collapse-borders/src/bin/solution.rs
@@ -1,17 +1,18 @@
 use std::time::Duration;
 
 use color_eyre::Result;
-use crossterm::event::{self, Event};
+use ratatui::crossterm::event::{self, Event};
 // ANCHOR: imports
 use ratatui::{
-    layout::{Constraint, Layout},
-    symbols,
-    widgets::{Block, Borders},
+    layout::{Constraint, Layout, Spacing},
+    symbols::merge::MergeStrategy,
+    widgets::Block,
     DefaultTerminal, Frame,
 };
 // ANCHOR_END: imports
 
-/// This example shows how to use custom borders to collapse borders between widgets.
+/// This example shows how to use the new Ratatui v0.30 border merging feature to collapse borders
+/// between widgets.
 /// See https://ratatui.rs/how-to/layout/collapse-borders for more info
 fn main() -> Result<()> {
     color_eyre::install()?;
@@ -34,64 +35,36 @@ fn key_pressed() -> Result<bool> {
     Ok(event::poll(Duration::from_millis(16))? && matches!(event::read()?, Event::Key(_)))
 }
 
-// ANCHOR: draw
 fn draw(frame: &mut Frame) {
     // create a layout that splits the screen into 2 equal columns and the right column
     // into 2 equal rows
 
     // ANCHOR: layout
-    // use a 49/51 split instead of 50/50 to ensure that any extra space is on the right
-    // side of the screen. This is important because the right side of the screen is
-    // where the borders are collapsed.
-    let [left, right] =
-        Layout::horizontal([Constraint::Percentage(49), Constraint::Percentage(51)])
-            .areas(frame.area());
-    // use a 49/51 split to ensure that any extra space is on the bottom
-    let [top_right, bottom_right] =
-        Layout::vertical([Constraint::Percentage(49), Constraint::Percentage(51)]).areas(right);
+    // Use Spacing::Overlap(1) to make the borders overlap
+    let [left, right] = Layout::horizontal([Constraint::Fill(1); 2])
+        .spacing(Spacing::Overlap(1))
+        .areas(frame.area());
+    let [top_right, bottom_right] = Layout::vertical([Constraint::Fill(1); 2])
+        .spacing(Spacing::Overlap(1))
+        .areas(right);
     // ANCHOR_END: layout
 
-    // ANCHOR: left_block
-    let left_block = Block::new()
-        // don't render the right border because it will be rendered by the right block
-        .borders(Borders::TOP | Borders::LEFT | Borders::BOTTOM)
-        .title("Left Block");
-    // ANCHOR_END: left_block
+    // ANCHOR: blocks
+    // Use merge_borders(MergeStrategy::Exact) to automatically handle border merging
+    let left_block = Block::bordered()
+        .title("Left Block")
+        .merge_borders(MergeStrategy::Exact);
 
-    // ANCHOR: top_right_block
-    // top right block must render the top left border to join with the left block
-    let top_right_border_set = symbols::border::Set {
-        top_left: symbols::line::NORMAL.horizontal_down,
-        ..symbols::border::PLAIN
-    };
-    let top_right_block = Block::new()
-        .border_set(top_right_border_set)
-        // don't render the bottom border because it will be rendered by the bottom block
-        .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
-        .title("Top Right Block");
-    // ANCHOR_END: top_right_block
+    let top_right_block = Block::bordered()
+        .title("Top Right Block")
+        .merge_borders(MergeStrategy::Exact);
 
-    // ANCHOR: bottom_right_block
-    // bottom right block must render:
-    // - top left border to join with the left block and top right block
-    // - top right border to join with the top right block
-    // - bottom left border to join with the left block
-    let collapsed_top_and_left_border_set = symbols::border::Set {
-        top_left: symbols::line::NORMAL.vertical_right,
-        top_right: symbols::line::NORMAL.vertical_left,
-        bottom_left: symbols::line::NORMAL.horizontal_up,
-        ..symbols::border::PLAIN
-    };
-    let bottom_right_block = Block::new()
-        .border_set(collapsed_top_and_left_border_set)
-        .borders(Borders::ALL)
-        .title("Bottom Right Block");
-    // ANCHOR_END: bottom_right_block
+    let bottom_right_block = Block::bordered()
+        .title("Bottom Right Block")
+        .merge_borders(MergeStrategy::Exact);
+    // ANCHOR_END: blocks
 
-    // ANCHOR: render
     frame.render_widget(left_block, left);
     frame.render_widget(top_right_block, top_right);
     frame.render_widget(bottom_right_block, bottom_right);
-    // ANCHOR_END: render
 }
-// ANCHOR_END: draw

--- a/src/content/docs/recipes/layout/collapse-borders.md
+++ b/src/content/docs/recipes/layout/collapse-borders.md
@@ -20,62 +20,38 @@ We can do better though, by collapsing borders. E.g.:
 
 ![solution](https://user-images.githubusercontent.com/381361/279935618-3b411b45-1a02-4f4c-af9f-7b68f766023e.png)
 
-The first thing we need to do is work out which borders to collapse. Because in the layout above we
-want to connect the bottom right block to the middle vertical border, we're going to need this to be
-rendered by the top left and bottom left blocks rather than the right block.
+Starting with Ratatui 0.30, collapsing borders has become much easier thanks to the new
+`merge_borders` method and `Spacing::Overlap`. The recipe is simple:
 
-We need to use the symbols module to achieve this so we add this to the imports:
+1.  Import `Spacing` and `MergeStrategy`.
 
-```rust ins={3}
-{{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs:imports}}
-```
+    ```rust ins={2-3}
+    {{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs:imports}}
+    ```
 
-Our first change is to the left block where we remove the right border:
+2.  Use `Spacing::Overlap(1)` in your layout to make borders overlap.
 
-```rust
-{{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs:left_block}}
-```
+    ```rust
+    {{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs:layout}}
+    ```
 
-Next, we see that the top left corner of the top right block joins with the top right corner of the
-left block, so we need to replace that with a T shape. We also see omit the bottom border as that
-will be rendered by the bottom right block. We use a custom [`symbols::border::Set`] to achieve
-this.
+3.  Add `.merge_borders(MergeStrategy::Exact)` to your blocks to automatically merge borders (see
+    [`MergeStrategy` documentation](https://docs.rs/ratatui/latest/ratatui/symbols/merge/enum.MergeStrategy.html#variants)
+    for details about the different strategies).
 
-[`symbols::border::Set`]: https://docs.rs/ratatui/latest/ratatui/symbols/border/struct.Set.html
+    ```rust
+    {{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs:blocks}}
+    ```
 
-```rust
-{{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs:top_right_block}}
-```
+Setting `merge_borders` to `MergeStrategy::Exact` or `MergeStrategy::Fuzzy` automatically handles
+all the complex border joining logic. The `Spacing::Overlap(1)` ensures that adjacent borders occupy
+the same space, allowing them to be merged.
 
-In the bottom right block, we see that the top right corner joins the left block's right border and
-so we need to rend this with a horizontal T shape pointing to the right. We need to do the same for
-the top right corner and the bottom left corner.
+:::tip
 
-```rust
-{{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs:bottom_right_block}}
-```
-
-Finally, render the blocks:
-
-```rust
-{{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs:render}}
-```
-
-If we left it here, then we'd be mostly fine, but in small areas we'd notice that the 50/50 split no
-longer looks right. This is due to the fact that by default we round up when splitting an odd number
-of rows or columns in 2 (e.g. 5 rows => 2.5/2.5 => 3/2). This is fine normally, but when we collapse
-borders between blocks, the first block has one extra row (or columns) already as it does not have
-the collapsed block. We can easily work around this issue by allocating a small amount of extra
-space to the last layout item (e.g. by using 49/51 or 33/33/34).
-
-```rust
-{{#include @code/recipes/how-to-collapse-borders/src/bin/solution.rs:layout}}
-```
-
-:::note
-
-If this sounds too complex, we're looking for some help to make this easier in
-<https://github.com/ratatui/ratatui/issues/605>.
+This new approach in Ratatui 0.30 replaces the complex manual border management that was required in
+earlier versions. If you're using an older version of Ratatui, you'll need to use custom border sets
+and selective border rendering as described in the previous version of this recipe.
 
 :::
 


### PR DESCRIPTION
~This has to wait for 0.30 release before merging.~
Changed base branch to `ratatui-0.30` so this can be merged.