### PR TITLE
chore: run ci on release branches

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     branches:
       - main
+      # release branches
+      - ratatui-*.*
   merge_group:
 
 # ensure that the workflow is only triggered once per PR,  subsequent pushes to the PR will cancel

--- a/.github/workflows/npm-ci.yml
+++ b/.github/workflows/npm-ci.yml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+      # release branches
+      - ratatui-*.*
   pull_request:
     branches:
       - main
+      # release branches
+      - ratatui-*.*
   merge_group:
 
 # ensure that the workflow is only triggered once per PR,  subsequent pushes to the PR will cancel

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -6,9 +6,13 @@ on:
   push:
     branches:
       - main
+      # release branches
+      - ratatui-*.*
   pull_request:
     branches:
       - main
+      # release branches
+      - ratatui-*.*
   merge_group:
 
 # ensure that the workflow is only triggered once per PR,  subsequent pushes to the PR will cancel


### PR DESCRIPTION
Currently CI doesn't run on PRs that have `ratatui-0.30` set as the base branch, this fixes it for all future releases.