### PR TITLE
Fix article usage from "a" to "an" for improved grammatical accuracy

### DIFF
--- a/src/content/docs/tutorials/index.md
+++ b/src/content/docs/tutorials/index.md
@@ -5,7 +5,7 @@ title: Tutorials
 - [Hello Ratatui](./hello-ratatui/): This tutorial takes you through the basics of creating a simple
   Ratatui application that displays "Hello World".
 - [Counter App](./counter-app/): This tutorial will set up the basics of a `ratatui` project by
-  building a app that displays a counter.
+  building an app that displays a counter.
 - [JSON Editor](./json-editor/): This tutorial will guide you through setting up a Rust project and
   organizing its structure for a `ratatui`-based application to edit json key value pairs. JSON
   Editor TUI will provide an interface for users to input key-value pairs, which are then converted


### PR DESCRIPTION
It should be "an app" not "a app".