### PR TITLE
doc: add suggestions regarding Cargo flags for Release builds

### DIFF
--- a/src/content/docs/recipes/apps/release-your-app.md
+++ b/src/content/docs/recipes/apps/release-your-app.md
@@ -31,6 +31,30 @@ Discord server / forum. This is not a comprehensive list, but it should help you
 [Ratatui Discord]: https://discord.gg/pMCEU9hNEj
 [Ratatui Forum]: https://forum.ratatui.rs
 
+## Cargo configuration
+
+Make sure you enable additional compiler optimizations for the release build. This will help reduce the size of the resulting binary. Add the following lines to your `Cargo.toml` file:
+
+```toml
+[profile.release]
+codegen-units = 1 # Allows compiler to perform better optimization.
+lto = true # Enables Link-time Optimization.
+opt-level = "s" # Prioritizes small binary size. Use `3` if you prefer speed.
+strip = true # Ensures debug symbols are removed.
+```
+
+### References
+
+- [codegen-units]: Tweaks a tradeoff between compile times and compile time optimizations.
+- [lto]: Enables Link-time Optimization.
+- [opt-level]: Determines the focus of the compiler in optimizations. Use `3` to optimize performance, `z` to optimize for size, and `s` for something in-between.
+- [strip]: Strip either symbols or debuginfo from a binary.
+
+[codegen-units]: https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units
+[lto]: https://doc.rust-lang.org/cargo/reference/profiles.html#lto
+[opt-level]: https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level
+[strip]: https://doc.rust-lang.org/cargo/reference/profiles.html#strip
+
 ## Screenshots
 
 Don't forget to add a screenshot / gif of your app in action. This will help users understand what

--- a/src/content/docs/recipes/apps/release-your-app.md
+++ b/src/content/docs/recipes/apps/release-your-app.md
@@ -21,6 +21,7 @@ Discord server / forum. This is not a comprehensive list, but it should help you
 - Add a `LICENSE` file to your project. This file should contain the license you are using for your
   app. The most common licenses are MIT and Apache 2.0. You can use [ChooseALicense] to help you
   choose a license.
+- Enable additional [optimizations] in your `Cargo.toml` file.  
 - Consider using `Release-plz` to automate your GitHub releases. This makes doing a release as easy
   as clicking merge on an automatically generated PR.
 - Submit your app to the [Awesome Ratatui] list, the [Ratatui Discord], and the [Ratatui Forum].
@@ -30,30 +31,7 @@ Discord server / forum. This is not a comprehensive list, but it should help you
 [Awesome Ratatui]: https://github.com/ratatui-org/awesome-ratatui
 [Ratatui Discord]: https://discord.gg/pMCEU9hNEj
 [Ratatui Forum]: https://forum.ratatui.rs
-
-## Cargo configuration
-
-Make sure you enable additional compiler optimizations for the release build. This will help reduce the size of the resulting binary. Add the following lines to your `Cargo.toml` file:
-
-```toml
-[profile.release]
-codegen-units = 1 # Allows compiler to perform better optimization.
-lto = true # Enables Link-time Optimization.
-opt-level = "s" # Prioritizes small binary size. Use `3` if you prefer speed.
-strip = true # Ensures debug symbols are removed.
-```
-
-### References
-
-- [codegen-units]: Tweaks a tradeoff between compile times and compile time optimizations.
-- [lto]: Enables Link-time Optimization.
-- [opt-level]: Determines the focus of the compiler in optimizations. Use `3` to optimize performance, `z` to optimize for size, and `s` for something in-between.
-- [strip]: Strip either symbols or debuginfo from a binary.
-
-[codegen-units]: https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units
-[lto]: https://doc.rust-lang.org/cargo/reference/profiles.html#lto
-[opt-level]: https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level
-[strip]: https://doc.rust-lang.org/cargo/reference/profiles.html#strip
+[optimizations]: https://ratatui.rs/recipes/apps/release-your-app/#optimizations
 
 ## Screenshots
 
@@ -85,3 +63,27 @@ CLI command to run the app,
   to show off your app.
 
 [VHS]: https://github.com/charmbracelet/vhs
+
+## Optimizations
+
+Make sure you enable additional compiler optimizations for the release build. This will help reduce the size of the resulting binary. Add the following lines to your `Cargo.toml` file:
+
+```toml
+[profile.release]
+codegen-units = 1 # Allows compiler to perform better optimization.
+lto = true # Enables Link-time Optimization.
+opt-level = "s" # Prioritizes small binary size. Use `3` if you prefer speed.
+strip = true # Ensures debug symbols are removed.
+```
+
+### References
+
+- [codegen-units]: Tweaks a tradeoff between compile times and compile time optimizations.
+- [lto]: Enables Link-time Optimization.
+- [opt-level]: Determines the focus of the compiler in optimizations. Use `3` to optimize performance, `z` to optimize for size, and `s` for something in-between.
+- [strip]: Strip either symbols or debuginfo from a binary.
+
+[codegen-units]: https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units
+[lto]: https://doc.rust-lang.org/cargo/reference/profiles.html#lto
+[opt-level]: https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level
+[strip]: https://doc.rust-lang.org/cargo/reference/profiles.html#strip


### PR DESCRIPTION
Partially resolves https://github.com/ratatui/ratatui-website/issues/930

In this PR, I want to introduce additional guidelines for Ratatui users regarding recommended Cargo options for their Ratatui-based apps. The recommendations are highly inspired by the similar Tauri [documentation](https://v2.tauri.app/concept/size/#cargo-configuration) (no licensing issues since Tauri docs are MIT licensed).

My motivation for that:

* By enabling better compiler optimizations, we can deliver better user experience for end users of Ratatui-based applications
* Enabling LTO, CG1 (`codegen-units = 1`) and `strip` reduces the resulting binary size - pretty common complaint about Rust apps. So we can improve the situation a bit on the ecosystem level

My personal motivation: I use a lot of Rust (and Ratatui) based apps in various environments, and some of my environments are pretty size-constrained. My main use-case for smaller apps is preparing minimal Docker images (especially when we talk about minimal sidecars).

Differences from Tauri recommendations:

* I removed potentially harmful recommendations like `panic = abort`. I am not saying that this is a bad recommendation - just saying this setting is a bit more dangerous than enabling LTO or `codegen-units`. If we are ok with that - no problem, we can also add a line about this setting too
* I left recommendations just for the stable Rustc. If we are interested enough in giving recommendations for Nightly-only stuff - we can add it later.

Maybe someone can find arguable a recommendation about `strip` setting. In this case, we can remove it from the default recommendation. However, personally, I think we should recommend it by default too.

I am open for the discussion about the recommended defaults for Ratatui.

I didn't test how my changes are rendered locally - just created this PR via GitHub web UI.