### PR TITLE
docs: add intelli-shell

### DIFF
--- a/src/content/docs/references.md
+++ b/src/content/docs/references.md
@@ -70,6 +70,8 @@ dependencies on crates.io and GitHub:
 - [igrep](https://github.com/konradsz/igrep): Interactive Grep
 - [todolist-rust](https://github.com/ebubekirgungor/todolist-rust): A terminal-based simple to-do
   app
+- [intelli-shell](https://github.com/lasantosr/intelli-shell): Interactive command template manager,
+  optionally enhanced with AI
 
 ### 🎼 Music and Media
 

--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -201,3 +201,15 @@ It is an alternative tool to AKHQ, Redpanda Console, or the Kafka plugin for Jet
 includes a search query language inspired by SQL, providing fine-grained filtering capabilities.
 
 ![yozefu demo](https://vhs.charm.sh/vhs-UpIJD2h92vKkj01XSS0r0.gif)
+
+---
+
+## [`intelli-shell`](https://github.com/lasantosr/intelli-shell)
+
+IntelliShell is a command-line tool that acts as a smart bookmark manager. It helps you find,
+organize, and reuse complex shell commands without ever leaving your terminal.
+
+A key feature is the flexible interface, which supports both a non-intrusive (inline) and an
+immersive (full-screen) TUI.
+
+![intelli-shell demo](https://github.com/lasantosr/intelli-shell/raw/HEAD/docs/src/images/demo.gif)


### PR DESCRIPTION
I wanted to add IntelliShell to the showcase to highlight its dual UI pattern, which allows for both inline and full-screen terminal user interfaces. This could be a valuable pattern for other developers to learn from when building similar tools.

I have also taken the time to document key modules in my own repository, such as [lib.rs](https://github.com/lasantosr/intelli-shell/blob/main/src/lib.rs), [app.rs](https://github.com/lasantosr/intelli-shell/blob/main/src/app.rs), and [tui.rs](https://github.com/lasantosr/intelli-shell/blob/main/src/tui.rs), to help other developers understand this pattern.

https://github.com/lasantosr/intelli-shell