### PR TITLE
fix: missing `crossterm` crate in cargo add for async counter

### DIFF
--- a/src/content/docs/tutorials/counter-async-app/index.md
+++ b/src/content/docs/tutorials/counter-async-app/index.md
@@ -38,7 +38,7 @@ If you were already using `crossterm` before, note that now you'll need to add
 You can use `cargo add` from the command line to add the above dependencies in one go:
 
 ```bash
-cargo add ratatui color-eyre tokio tokio-util futures --features tokio/full,crossterm/event-stream
+cargo add ratatui crossterm color-eyre tokio tokio-util futures --features tokio/full,crossterm/event-stream
 ```
 
 :::


### PR DESCRIPTION
The `cargo add` command will crash if crossterm isn't install because of the crossterm feature.

`ratatui` is listed in the command, thus so should `crossterm`.
