### PR TITLE
Add 'lottie' screenwriting editor to showcase

### DIFF
--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -123,7 +123,7 @@ Ranger-like terminal file manager written in Rust
 A simple yet powerful screenwriting editor for the [Fountain](https://www.fountain.io/) plain-text
 screenplay format. Fast, lightweight, and built for writers who live in the terminal.
 
-[![lottie demo](https://asciinema.org/a/1jYgFFAeaettGJZa.svg)](https://asciinema.org/a/1jYgFFAeaettGJZa)
+![lottie demo](https://github.com/coignard/lottie/blob/main/assets/demo.gif?raw=true)
 
 ---
 

--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -120,8 +120,7 @@ Ranger-like terminal file manager written in Rust
 
 ## [`lottie`](https://github.com/coignard/lottie)
 
-A simple yet powerful screenwriting editor for the [Fountain](https://www.fountain.io/) plain-text
-screenplay format. Fast, lightweight, and built for writers who live in the terminal.
+A simple yet powerful Fountain screenplay editor.
 
 ![lottie demo](https://github.com/coignard/lottie/blob/main/assets/demo.gif?raw=true)
 

--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -118,6 +118,15 @@ Ranger-like terminal file manager written in Rust
 
 ---
 
+## [`lottie`](https://github.com/coignard/lottie)
+
+A simple yet powerful screenwriting editor for the [Fountain](https://www.fountain.io/) plain-text
+screenplay format. Fast, lightweight, and built for writers who live in the terminal.
+
+[![lottie demo](https://asciinema.org/a/1jYgFFAeaettGJZa.svg)](https://asciinema.org/a/1jYgFFAeaettGJZa)
+
+---
+
 ## [`material`](https://crates.io/crates/material)
 
 A material design color palette for the terminal.


### PR DESCRIPTION
Hi there!

I'd like to add my app, lottie, to the showcase: it's a terminal screenwriting editor for the Fountain plain-text screenplay format, built with ratatui. It's a Rust port of Beat, designed for writers who live in the terminal.

I believe it meets the showcase criteria: the UI is clean and intentional, the demo shows the app's purpose clearly, and it's a stable release.

René Coignard