### PR TITLE
showcase: add rustnet

### DIFF
--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -202,6 +202,14 @@ An application to manage markdown notes from your terminal and compile them to H
 
 ---
 
+## [`rustnet`](https://github.com/domcyrus/rustnet)
+
+Per-process network monitoring for your terminal with deep packet inspection. Cross-platform, sandboxed.
+
+![rustnet demo](https://github.com/domcyrus/rustnet/blob/main/assets/rustnet.gif?raw=true)
+
+---
+
 ## [`scope-tui`](https://github.com/alemidev/scope-tui)
 
 A simple oscilloscope/vectorscope/spectroscope for your terminal


### PR DESCRIPTION
## Summary

Adds rustnet to the app showcase, slotted alphabetically between `rucola` and `scope-tui`.

- Repo: https://github.com/domcyrus/rustnet (~2k stars, Apache-2.0)
- Built with ratatui + crossterm. Demonstrates eBPF process attribution, deep packet inspection, and a multi-tab TUI with filtering and live traffic charts.
- Demo GIF: https://github.com/domcyrus/rustnet/blob/main/assets/rustnet.gif

I've reviewed the showcase criteria in #986. If the existing demo doesn't yet meet the visual bar (font size, palette, length), happy to re-record with vhs and resubmit, or close this if awesome-ratatui is the better fit (rustnet is already listed there).