### PR TITLE
docs: remove prelude from all markdown files

### DIFF
--- a/src/content/docs/concepts/backends/alternate-screen.md
+++ b/src/content/docs/concepts/backends/alternate-screen.md
@@ -21,16 +21,21 @@ you can see how the program behaves differently.
 
 ```rust collapse={1-17, 25-30}
 use std::{
-  io::{stderr, Result},
-  thread::sleep,
-  time::Duration,
+    io::{Result, stderr},
+    thread::sleep,
+    time::Duration,
 };
 
-use ratatui::crossterm::{
-  terminal::{EnterAlternateScreen, LeaveAlternateScreen},
-  ExecutableCommand,
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    crossterm::{
+        ExecutableCommand,
+        terminal::{EnterAlternateScreen, LeaveAlternateScreen},
+    },
+    layout::Rect,
+    widgets::Paragraph,
 };
-use ratatui::{prelude::*, widgets::*};
 
 fn main() -> Result<()> {
   let should_enter_alternate_screen = std::env::args().nth(1).unwrap().parse::<bool>().unwrap();

--- a/src/content/docs/concepts/layout.md
+++ b/src/content/docs/concepts/layout.md
@@ -43,7 +43,7 @@ for i in 0..10 {
 A simple example of using the layout struct might look like this:
 
 ```rust
-use ratatui::prelude::*;
+use ratatui::layout::{Constraint, Direction, Layout};
 
 let layout = Layout::default()
     .direction(Direction::Vertical)

--- a/src/content/docs/faq.md
+++ b/src/content/docs/faq.md
@@ -252,7 +252,13 @@ each iteration. It does not handle input and users have use another library (lik
 as backends.
 
 ```rust
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    Terminal,
+    backend::CrosstermBackend,
+    crossterm,
+    layout::{Alignment, Constraint, Direction, Layout, Rect},
+    widgets::{Block, Borders, Paragraph},
+};
 
 fn init() -> Result<(), Box<dyn std::error::Error>> {
   crossterm::terminal::enable_raw_mode()?;
@@ -297,7 +303,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
       f.render_widget(
         Paragraph::new("Hello World!\n\n\n'q' to quit")
           .block(
-            Block::default().title(block::Title::from("Ratatui").alignment(Alignment::Center)).borders(Borders::all()),
+            Block::default().title("Ratatui").title_alignment(Alignment::Center).borders(Borders::all()),
           )
           .alignment(Alignment::Center),
         rect,

--- a/src/content/docs/recipes/render/display-text.md
+++ b/src/content/docs/recipes/render/display-text.md
@@ -16,7 +16,13 @@ It is the most basic unit of displaying text in `ratatui`.
 The examples below assume the following imports:
 
 ```rust
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    Frame,
+    layout::Alignment,
+    style::{Color, Style, Stylize},
+    text::{Line, Span, Text},
+    widgets::*,
+};
 ```
 
 A `Span` consists of "content" and a "style" for the content. And a `Span` can be created in a few

--- a/src/content/docs/tutorials/counter-app/_multiple-functions.md
+++ b/src/content/docs/tutorials/counter-app/_multiple-functions.md
@@ -14,14 +14,16 @@ previous functionality into separate functions.
 The first thing you might consider doing is reorganizing imports with qualified names.
 
 ```rust
+use ratatui::Frame;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::widgets::Paragraph;
+
+use color_eyre::eyre::Result;
 use ratatui::crossterm::{
-  event::{self, Event::Key, KeyCode::Char},
-  execute,
-  terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
-use ratatui::{
-  prelude::{CrosstermBackend, Terminal, Frame},
-  widgets::Paragraph,
+    event::{self, Event::Key, KeyCode::Char},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 ```
 
@@ -219,15 +221,16 @@ understand and work with but also set the stage for future enhancements and exte
 Here's the full code for reference:
 
 ```rust
+use ratatui::Frame;
+use ratatui::Terminal;
+use ratatui::backend::CrosstermBackend;
+use ratatui::widgets::Paragraph;
+
 use color_eyre::eyre::Result;
 use ratatui::crossterm::{
-  event::{self, Event::Key, KeyCode::Char},
-  execute,
-  terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
-use ratatui::{
-  prelude::{CrosstermBackend, Terminal, Frame},
-  widgets::Paragraph,
+    event::{self, Event::Key, KeyCode::Char},
+    execute,
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 
 

--- a/src/content/docs/tutorials/counter-async-app/actions.md
+++ b/src/content/docs/tutorials/counter-async-app/actions.md
@@ -96,14 +96,15 @@ Here's the full single file version of the counter app using the `Action` enum f
 mod tui;
 
 use color_eyre::eyre::Result;
-use ratatui::crossterm::{
-  event::{self, Event::Key, KeyCode::Char},
-  execute,
-  terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
-};
+use ratatui::crossterm::event::Event;
+use ratatui::widgets::Paragraph;
 use ratatui::{
-  prelude::{CrosstermBackend, Terminal},
-  widgets::Paragraph,
+    Frame,
+    crossterm::{
+        event::{self, Event::Key, KeyCode::Char},
+        execute,
+        terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
+    },
 };
 
 // App state

--- a/src/content/docs/tutorials/counter-async-app/async-increment-decrement.md
+++ b/src/content/docs/tutorials/counter-async-app/async-increment-decrement.md
@@ -12,7 +12,14 @@ Here's the code for your reference:
 use std::time::Duration;
 
 use color_eyre::eyre::Result;
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    crossterm,
+    layout::Alignment,
+    style::{Color, Style},
+    widgets::{Block, BorderType, Borders, Paragraph},
+};
 use tokio::sync::mpsc;
 
 pub fn initialize_panic_handler() {

--- a/src/content/docs/tutorials/counter-async-app/full-async-events.md
+++ b/src/content/docs/tutorials/counter-async-app/full-async-events.md
@@ -118,8 +118,8 @@ Here's the code for the fully async application:
 mod tui;
 
 use color_eyre::eyre::Result;
-use ratatui::crossterm::event::KeyCode::Char;
-use ratatui::{prelude::CrosstermBackend, widgets::Paragraph};
+use ratatui::{Frame, crossterm::event::KeyCode::Char, widgets::Paragraph};
+use tui::Event;
 use tui::Event;
 
 // App state
@@ -140,7 +140,7 @@ fn update(app: &mut App, event: Event) {
         Char('j') => app.counter += 1,
         Char('k') => app.counter -= 1,
         Char('q') => app.should_quit = true,
-        _ => Action::None,
+        _ => {}
       }
     },
     _ => {},

--- a/src/content/docs/tutorials/counter-async-app/sync-increment-decrement.md
+++ b/src/content/docs/tutorials/counter-async-app/sync-increment-decrement.md
@@ -79,10 +79,15 @@ graph TD
 Here's the full code for your reference:
 
 ```rust
-use std::time::Duration;
-
 use color_eyre::eyre::Result;
-use ratatui::{prelude::*, widgets::*};
+use ratatui::{
+    Frame, Terminal,
+    backend::CrosstermBackend,
+    crossterm::{self, event},
+    layout::Alignment,
+    style::{Color, Style},
+    widgets::{Block, BorderType, Borders, Paragraph},
+};
 use tokio::sync::mpsc;
 
 pub fn initialize_panic_handler() {


### PR DESCRIPTION
fixes #750 