### PR TITLE
fix: prevent layout shift when toggling theme on landing page

### DIFF
--- a/src/components/CompanyLogos.astro
+++ b/src/components/CompanyLogos.astro
@@ -50,7 +50,7 @@ const logos = [
     lightMode: aws_black,
     href: "https://github.com/aws/amazon-q-developer-cli",
     aria: "AWS",
-    class: "h-[23px] max-xl:h-[18px] max-sm:h-[15px] mt-1 dark:mt-5",
+    class: "h-[23px] max-xl:h-[18px] max-sm:h-[15px] mt-1",
   },
   {
     darkMode: electronic_arts_white,
@@ -92,7 +92,7 @@ const logos = [
   >
     {
       logos.map((logo) => (
-        <a class="no-underline" href={logo.href} target="_blank" aria-label={logo.aria}>
+        <a class="not-content no-underline" href={logo.href} target="_blank" aria-label={logo.aria}>
           <img
             src={logo.lightMode.src}
             alt={logo.aria}

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -31,7 +31,7 @@ import MainButtons from "@components/MainButtons.astro";
 import HideHeader from "@components/HideHeader.astro";
 import ThemeSwitch from "@components/ThemeSwitch.astro";
 
-<div class="flex justify-center landing-mono pt-3 dark:pt-0">
+<div class="flex justify-center landing-mono pt-3">
   <div>
     <h1>Ratatui</h1>
     <RandomDots
@@ -51,13 +51,13 @@ import ThemeSwitch from "@components/ThemeSwitch.astro";
         <div class="max-xl:text-center">
           <div class="flex max-sm:flex-wrap max-sm:justify-center items-end pb-10">
             <div class="w-[150px] max-2xl:w-[100px] max-sm:w-[150px]">
-              <a class="no-underline" href="https://github.com/ratatui/ratatui/" aria-label="Ratatui GitHub Repository">
+              <a class="not-content no-underline" href="https://github.com/ratatui/ratatui/" aria-label="Ratatui GitHub Repository">
                 <img src={heroLight.src} alt="Ratatui Logo" class="block dark:hidden" />
                 <img src={heroDark.src} alt="Ratatui Logo" class="hidden dark:block" />
               </a>
             </div>
             <div>
-              <a class="no-underline" href="https://github.com/ratatui/ratatui/" aria-label="Ratatui GitHub Repository">
+              <a class="not-content no-underline" href="https://github.com/ratatui/ratatui/" aria-label="Ratatui GitHub Repository">
                 <img src={logoTextLight.src} alt="Ratatui Logo" class="max-h-[100px] max-2xl:max-h-[80px] block dark:hidden" />
                 <img src={logoTextDark.src} alt="Ratatui Logo" class="max-h-[100px] max-2xl:max-h-[80px] hidden dark:block" />
               </a>


### PR DESCRIPTION

Closes #1075

## Problem
Toggling the theme switcher on the landing page shifts most of the UI up and down instead of keeping it fixed.

## Cause
The splash page sits inside Starlight's `.sl-markdown-content`, whose flow-spacing rule adds a top margin to any element preceded by a sibling. Each
theme-swapped logo stacks two `<img>` (light + dark) toggled via `dark:hidden`/`dark:block`. A `display:none` sibling still counts for the `+` selector,
so the visible image is the first child in light (no margin) but the second in dark, which gets the margin. That makes rows taller in dark and pushes
everything below down by about 16px on every toggle.

## Fix
- Add `not-content` to the image-pair anchors (hero, logo-text, company logos). This is Starlight's intended opt-out, via the rule's `:where(.not-content
*)` exclusion.
- Remove `dark:pt-0` on the root wrapper (a second per-theme shift).
- Remove the AWS logo's `dark:mt-5` (an unneeded per-theme margin).

## Test note
Verified with a headless browser: page height and every key element match across light and dark (Δ0), where they previously shifted 16px. `prettier` and `astro check` pass.


