### PR TITLE
Document when to make custom widgets

### DIFF
--- a/src/content/docs/concepts/widgets.md
+++ b/src/content/docs/concepts/widgets.md
@@ -165,6 +165,34 @@ In Ratatui, widgets are implemented as Rust traits, which allow for easy impleme
 extension. The two main traits for widgets are [`Widget`] and [`StatefulWidget`], which provide the
 basic functionality for rendering and managing the state of a Widget.
 
+### When to Make a Custom Widget
+
+All of these are valid ways to organize rendering:
+
+- keep a small UI in one render function
+- split larger areas into helper render functions
+- create structs that implement [`Widget`] or [`StatefulWidget`]
+
+Implementing a widget is useful when a section of UI needs a meaningful boundary, not only when it
+will be reused. A helper such as `fn render_sidebar(area, buf, app: &App)` can accidentally depend
+on any field in `App`. A widget struct makes the inputs explicit, such as
+`Sidebar { selected, items }`, and the render implementation can only use those fields.
+
+That boundary is helpful when a section has a clear contract, is reused, is getting large, or should
+only access a limited subset of application state. Small one-off sections can stay as render
+functions until a widget boundary would make the code easier to understand.
+
+Choose the implementation form based on ownership and state:
+
+- use `impl Widget for &MyWidget` for reusable widgets that do not mutate themselves during render
+- use `impl Widget for MyWidget` for cheap ephemeral widgets created fresh each frame
+- use `impl Widget for &mut MyWidget` when rendering updates state owned by the widget
+- use [`StatefulWidget`] when state should live outside the widget and persist independently, such as
+  selection, scroll offset, or cursor position
+
+A useful state question is: if this widget value is recreated, should its state reset? If yes,
+widget-owned state can be fine. If no, keep the state outside the widget and pass it in.
+
 Here's an example of implementing the [`Widget`] trait for a simple greeting Widget:
 
 ```rust

--- a/src/content/docs/recipes/widgets/custom.md
+++ b/src/content/docs/recipes/widgets/custom.md
@@ -9,6 +9,9 @@ unique component tailored to specific needs. In such cases, creating a custom wi
 invaluable. This page will guide you through the process of designing and implementing custom
 widgets.
 
+If you are deciding whether a section of UI should be a custom widget or just another render
+function, see [When to Make a Custom Widget](/concepts/widgets/#when-to-make-a-custom-widget).
+
 ## `Widget` trait
 
 At the core of creating a custom widget is the `Widget` trait. Any struct that implements this trait

--- a/src/content/docs/showcase/apps.md
+++ b/src/content/docs/showcase/apps.md
@@ -259,7 +259,7 @@ assist with the analysis of networking issues.
 
 Play 2048 in your terminal
 
-![twozero48 demo](./twozero48.gif)
+![twozero48 demo](./apps/twozero48.gif)
 
 ---
 


### PR DESCRIPTION
## Summary

- add guidance on when to use a custom widget versus render functions
- describe widgets as boundaries around a section of UI and its explicit inputs
- link the custom widget recipe back to the concepts guidance
- fix the `twozero48` showcase image path that blocked the current pnpm/Cloudflare build

## Verification

- `npx markdownlint-cli2 src/content/docs/concepts/widgets.md src/content/docs/recipes/widgets/custom.md`
- `pnpm build`
