### PR TITLE
feat: make the rat in the footer move & jump

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -164,7 +164,14 @@ import ThemeSwitch from "@components/ThemeSwitch.astro";
               <ThemeSwitch />
             </div>
           </div>
-          <div class="pt-3 text-2xl"><img alt="Rat icon" class="w-6 m-auto" src={rat.src} /></div>
+          <div class="pt-3 text-2xl">
+            <input id="rat-jump" type="checkbox" class="rat-jump hidden" checked />
+            <label for="rat-jump" class="cursor-pointer inline-block">
+              <span class="inline-block">
+                <img alt="Rat icon" class="w-6 m-auto" src={rat.src} />
+              </span>
+            </label>
+          </div>
         </div>
       </div>
     </div>

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -281,3 +281,52 @@ main .content-panel:first-child:not(:has(*)) {
 .bracket-effect:hover::after {
   opacity: 1;
 }
+
+/* Rat emoji wiggle, shake & click-jump */
+.rat-jump + label {
+  animation: rat-run 10s linear infinite;
+}
+
+.rat-jump + label span {
+  animation: rat-shake 0.2s linear infinite;
+  filter: sepia(1) saturate(5) hue-rotate(-60deg);
+}
+
+.rat-jump:checked + label span {
+  animation: rat-wiggle 0.8s linear infinite;
+  filter: none;
+}
+
+.rat-jump:checked + label img {
+  animation: rat-jump 0.6s linear;
+}
+
+@keyframes rat-run {
+  0%,
+  100% { transform: translateX(-80px) scaleX(-1); }
+  48%  { transform: translateX(80px)  scaleX(-1); }
+  50%  { transform: translateX(80px)  scaleX(1); }
+  98%  { transform: translateX(-80px) scaleX(1); }
+}
+
+@keyframes rat-wiggle {
+  0%,
+  100% { transform: rotate(0)     translateY(0); }
+  25%  { transform: rotate(-8deg) translateY(-2px); }
+  75%  { transform: rotate(8deg)  translateY(2px); }
+}
+
+@keyframes rat-shake {
+  0%,
+  100% { transform: translateY(0); }
+  25%  { transform: translateY(-2px); }
+  50%  { transform: translateY(2px); }
+  75%  { transform: translateY(-1px); }
+}
+
+@keyframes rat-jump {
+  0%   { transform: translateY(0)     rotate(0)      scale(1); }
+  30%  { transform: translateY(-28px) rotate(180deg) scale(1.15); }
+  70%  { transform: translateY(-6px)  rotate(360deg) scale(0.95); }
+  100% { transform: translateY(0)     rotate(360deg) scale(1); }
+}


### PR DESCRIPTION
The 🐀 in the footer now runs left-right.

Using only CSS & HTML 'checkbox hack':
 - Unchecked: Red tint + shaking.
 - Checked: Wiggles + jump animation. 

https://github.com/user-attachments/assets/4e67b807-4cd6-4fa6-a928-d8703f7586f9