### PR TITLE
docs: add async application guidance

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+pnpm-lock.yaml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
+name = "async-applications"
+version = "0.0.0"
+dependencies = [
+ "color-eyre",
+ "crossterm 0.29.0",
+ "futures",
+ "ratatui 0.30.2",
+ "tokio",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +725,7 @@ dependencies = [
  "crossterm_winapi",
  "derive_more",
  "document-features",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix 1.1.2",
@@ -936,7 +948,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2747,6 +2759,27 @@ dependencies = [
 
 [[package]]
 name = "ratatui"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdef7f9be5c0122f890d58bdf4d964349ba6a6161f705907526d891efabba57d"
+dependencies = [
+ "bitflags 2.12.1",
+ "cassowary",
+ "compact_str 0.8.0",
+ "crossterm 0.28.1",
+ "instability",
+ "itertools 0.13.0",
+ "lru 0.12.5",
+ "paste",
+ "strum 0.26.3",
+ "strum_macros 0.26.4",
+ "unicode-segmentation",
+ "unicode-truncate 1.1.0",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "ratatui"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
@@ -3180,7 +3213,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3841,6 +3874,14 @@ dependencies = [
  "smawk",
  "unicode-linebreak",
  "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "the-elm-architecture"
+version = "0.0.0"
+dependencies = [
+ "color-eyre",
+ "ratatui 0.28.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 # See https://doc.rust-lang.org/cargo/reference/workspaces.html
 [workspace]
 members = [
+  "code/concepts/*",
   "code/examples/*",
   "code/recipes/*",
   "code/showcase/*",

--- a/code/concepts/async-applications/Cargo.toml
+++ b/code/concepts/async-applications/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "async-applications"
+version.workspace = true
+authors.workspace = true
+description.workspace = true
+documentation.workspace = true
+repository.workspace = true
+keywords.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish.workspace = true
+
+# ANCHOR: dependencies
+[dependencies]
+color-eyre = "0.6"
+crossterm = { version = "0.29", features = ["event-stream"] }
+futures = "0.3"
+ratatui = "0.30"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+# ANCHOR_END: dependencies

--- a/code/concepts/async-applications/src/drain.rs
+++ b/code/concepts/async-applications/src/drain.rs
@@ -1,0 +1,43 @@
+//! The "drain then draw" example.
+
+use std::time::Duration;
+
+use color_eyre::Result;
+use ratatui::DefaultTerminal;
+use tokio::sync::mpsc;
+
+use crate::{App, UiMessage, MAX_EVENTS_PER_TURN};
+
+// ANCHOR: drain_then_draw
+fn drain_then_draw(
+    app: &mut App,
+    ui_rx: &mut mpsc::Receiver<UiMessage>,
+    terminal: &mut DefaultTerminal,
+) -> Result<()> {
+    let mut dirty = false;
+    let mut drained = 0;
+
+    while drained < MAX_EVENTS_PER_TURN && crossterm::event::poll(Duration::ZERO)? {
+        let event = crossterm::event::read()?;
+        app.handle_terminal_event(event);
+        dirty = true;
+        drained += 1;
+    }
+
+    while drained < MAX_EVENTS_PER_TURN {
+        let Ok(message) = ui_rx.try_recv() else {
+            break;
+        };
+
+        app.handle_message(message);
+        dirty = true;
+        drained += 1;
+    }
+
+    if dirty {
+        terminal.draw(|frame| app.render(frame))?;
+    }
+
+    Ok(())
+}
+// ANCHOR_END: drain_then_draw

--- a/code/concepts/async-applications/src/main.rs
+++ b/code/concepts/async-applications/src/main.rs
@@ -1,0 +1,142 @@
+//! Compile-tested examples for the Async Applications page.
+//!
+//! The anchored regions are included verbatim in
+//! `src/content/docs/concepts/application-patterns/async-applications.md`. The stubs at the bottom
+//! of each file stand in for the application types the page treats as placeholders.
+#![allow(dead_code)]
+
+// ANCHOR: main_thread_owner
+use std::time::{Duration, Instant};
+
+use color_eyre::Result;
+use ratatui::DefaultTerminal;
+use tokio::sync::mpsc;
+
+const MAX_EVENTS_PER_TURN: usize = 64;
+
+fn main() -> Result<()> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?;
+    let terminal = ratatui::init();
+    let (ui_tx, ui_rx) = mpsc::channel(128);
+
+    runtime.spawn({
+        let ui_tx = ui_tx.clone();
+        async move {
+            let message = match load_items().await {
+                Ok(items) => UiMessage::ItemsLoaded(items),
+                Err(error) => UiMessage::ItemsFailed(error.to_string()),
+            };
+            let _ = ui_tx.send(message).await;
+        }
+    });
+
+    let result = run_terminal(terminal, ui_rx);
+    ratatui::restore();
+    runtime.shutdown_timeout(Duration::from_secs(1));
+    result
+}
+
+fn run_terminal(mut terminal: DefaultTerminal, mut ui_rx: mpsc::Receiver<UiMessage>) -> Result<()> {
+    let mut app = App::default();
+    let frame_interval = Duration::from_millis(16);
+    let max_poll = Duration::from_millis(16);
+    let mut next_frame = Instant::now();
+    let mut dirty = true;
+
+    while !app.should_quit() {
+        let now = Instant::now();
+        let timeout = if dirty {
+            next_frame.saturating_duration_since(now).min(max_poll)
+        } else {
+            max_poll
+        };
+
+        if crossterm::event::poll(timeout)? {
+            for _ in 0..MAX_EVENTS_PER_TURN {
+                let event = crossterm::event::read()?;
+                app.handle_terminal_event(event);
+                dirty = true;
+
+                if !crossterm::event::poll(Duration::ZERO)? {
+                    break;
+                }
+            }
+        }
+
+        let mut drained = 0;
+        while drained < MAX_EVENTS_PER_TURN {
+            let Ok(message) = ui_rx.try_recv() else {
+                break;
+            };
+            app.handle_message(message);
+            dirty = true;
+            drained += 1;
+        }
+
+        if dirty && Instant::now() >= next_frame {
+            terminal.draw(|frame| app.render(frame))?;
+            dirty = false;
+            next_frame = Instant::now() + frame_interval;
+        }
+    }
+
+    Ok(())
+}
+// ANCHOR_END: main_thread_owner
+
+// ANCHOR: messages
+enum UiMessage {
+    ItemsLoaded(Vec<Item>),
+    ItemsFailed(String),
+    ProgressChanged { job: JobId, percent: u8 },
+    RenderRequested,
+}
+
+async fn report_loaded_items(ui_tx: mpsc::Sender<UiMessage>) {
+    let message = match load_items().await {
+        Ok(items) => UiMessage::ItemsLoaded(items),
+        Err(error) => UiMessage::ItemsFailed(error.to_string()),
+    };
+
+    let _ = ui_tx.send(message).await;
+}
+// ANCHOR_END: messages
+
+mod drain;
+mod single_task;
+mod stale;
+
+/// Stand-in for the application state the page leaves as a placeholder.
+#[derive(Default)]
+struct App {
+    quit: bool,
+    dirty: bool,
+    search_generation: u64,
+    search_query: String,
+    search_results: Vec<Item>,
+    search_error: Option<String>,
+}
+
+impl App {
+    fn should_quit(&self) -> bool {
+        self.quit
+    }
+
+    fn handle_terminal_event(&mut self, _event: crossterm::event::Event) {}
+
+    fn handle_message(&mut self, _message: UiMessage) {}
+
+    fn render(&self, _frame: &mut ratatui::Frame) {}
+}
+
+#[derive(Clone)]
+struct Item;
+
+type JobId = u64;
+
+/// Stand-in for the slow async work the page leaves as a placeholder.
+async fn load_items() -> Result<Vec<Item>> {
+    Ok(vec![])
+}

--- a/code/concepts/async-applications/src/single_task.rs
+++ b/code/concepts/async-applications/src/single_task.rs
@@ -1,0 +1,52 @@
+//! The "single async UI task" example.
+
+use crate::{load_items, App, UiMessage};
+
+// ANCHOR: single_task
+use std::time::Duration;
+
+use color_eyre::Result;
+use crossterm::event::EventStream;
+use futures::StreamExt;
+use ratatui::DefaultTerminal;
+use tokio::sync::mpsc;
+
+async fn run(mut terminal: DefaultTerminal) -> Result<()> {
+    let mut terminal_events = EventStream::new();
+    let mut render_tick = tokio::time::interval(Duration::from_millis(16));
+    let (worker_tx, mut worker_rx) = mpsc::channel(32);
+    let mut app = App::default();
+    let mut dirty = true;
+
+    tokio::spawn(async move {
+        let message = match load_items().await {
+            Ok(items) => UiMessage::ItemsLoaded(items),
+            Err(error) => UiMessage::ItemsFailed(error.to_string()),
+        };
+        let _ = worker_tx.send(message).await;
+    });
+
+    while !app.should_quit() {
+        tokio::select! {
+            _ = render_tick.tick(), if dirty => {
+                terminal.draw(|frame| app.render(frame))?;
+                dirty = false;
+            }
+            maybe_event = terminal_events.next() => match maybe_event {
+                Some(Ok(event)) => {
+                    app.handle_terminal_event(event);
+                    dirty = true;
+                }
+                Some(Err(error)) => return Err(error.into()),
+                None => break,
+            },
+            Some(message) = worker_rx.recv() => {
+                app.handle_message(message);
+                dirty = true;
+            }
+        }
+    }
+
+    Ok(())
+}
+// ANCHOR_END: single_task

--- a/code/concepts/async-applications/src/stale.rs
+++ b/code/concepts/async-applications/src/stale.rs
@@ -1,0 +1,60 @@
+//! The "discard stale search results" example.
+//!
+//! This module has its own `UiMessage` so the search variants stay local to the example; a real
+//! application would add them to its single message enum.
+
+use color_eyre::Result;
+use tokio::sync::mpsc;
+
+use crate::{App, Item};
+
+enum UiMessage {
+    SearchFinished { generation: u64, results: Vec<Item> },
+    SearchFailed { generation: u64, error: String },
+}
+
+/// Stand-in for the slow search the page leaves as a placeholder.
+async fn search(_query: String) -> Result<Vec<Item>> {
+    Ok(vec![])
+}
+
+// ANCHOR: discard_stale
+fn start_search(app: &mut App, ui_tx: &mpsc::Sender<UiMessage>) {
+    app.search_generation += 1;
+    let generation = app.search_generation;
+    let query = app.search_query.clone();
+    let ui_tx = ui_tx.clone();
+
+    tokio::spawn(async move {
+        let message = match search(query).await {
+            Ok(results) => UiMessage::SearchFinished {
+                generation,
+                results,
+            },
+            Err(error) => UiMessage::SearchFailed {
+                generation,
+                error: error.to_string(),
+            },
+        };
+
+        let _ = ui_tx.send(message).await;
+    });
+}
+
+fn handle_message(app: &mut App, message: UiMessage) {
+    match message {
+        UiMessage::SearchFinished {
+            generation,
+            results,
+        } if generation == app.search_generation => {
+            app.search_results = results;
+            app.dirty = true;
+        }
+        UiMessage::SearchFailed { generation, error } if generation == app.search_generation => {
+            app.search_error = Some(error);
+            app.dirty = true;
+        }
+        _ => {}
+    }
+}
+// ANCHOR_END: discard_stale

--- a/code/concepts/the-elm-architecture/Cargo.toml
+++ b/code/concepts/the-elm-architecture/Cargo.toml
@@ -7,8 +7,8 @@ documentation.workspace = true
 repository.workspace = true
 keywords.workspace = true
 license.workspace = true
-edition.workspace = true
-rust-version.workspace = true
+edition = "2024"
+rust-version = "1.85"
 publish.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/code/concepts/the-elm-architecture/src/main.rs
+++ b/code/concepts/the-elm-architecture/src/main.rs
@@ -1,9 +1,9 @@
 use std::time::Duration;
 
 use ratatui::{
+    Frame,
     crossterm::event::{self, Event, KeyCode},
     widgets::Paragraph,
-    Frame,
 };
 
 // ANCHOR: model
@@ -114,14 +114,14 @@ fn update(model: &mut Model, msg: Message) -> Option<Message> {
 
 mod tui {
     use ratatui::{
+        Terminal,
         backend::{Backend, CrosstermBackend},
         crossterm::{
-            terminal::{
-                disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
-            },
             ExecutableCommand,
+            terminal::{
+                EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode,
+            },
         },
-        Terminal,
     };
     use std::{io::stdout, panic};
 

--- a/src/content/docs/concepts/application-patterns/async-application-examples.md
+++ b/src/content/docs/concepts/application-patterns/async-application-examples.md
@@ -1,0 +1,286 @@
+---
+title: Async Application Examples
+sidebar:
+  order: 5
+---
+
+[Async Applications](/concepts/application-patterns/async-applications/) gives the rules for
+combining Ratatui with an async runtime: one terminal owner, blocking draw boundaries, bounded
+channels, burst draining, and stale-work guards. This page is the companion source survey. It audits
+what older async tutorials teach before they teach the ownership contract, then walks through real
+applications — Ratatui apps, Crossterm TUIs, and adjacent terminal stacks — showing how each one
+structures terminal ownership, draining, backpressure, cancellation, and handoffs.
+
+## Audit older async material
+
+Older Ratatui async tutorials and templates are historical material, but many of them teach the
+shape of an async loop before they teach the terminal ownership contract. If an application was
+copied from them, review it for these gaps before adding more async work:
+
+- **Entry point as architecture.** A Tokio entry point lets the program spawn tasks and await
+  futures, but it does not change the terminal into an async resource. Choose the terminal owner
+  first, then decide which background jobs send messages into that owner.
+- **Terminal work split by task name.** The old [`async-template`] book sketches a render task and
+  an event task as independent lanes. If one lane owns [`EventStream`] and another owns
+  [`Terminal::draw`], terminal queries, suspend/resume, child TUI handoffs, and inline viewport
+  setup become harder to order. Prefer one terminal owner that reads events and draws, with other
+  tasks sending application messages or render requests.
+- **[`EventStream`] as ordinary async stdin.** It is a stream-shaped API, but Crossterm implements
+  it with a helper thread and the same internal event reader used by terminal queries. Code derived
+  from older examples should not add direct [`event::read`][`crossterm::event::read`] /
+  [`poll`][`crossterm::event::poll`], [`cursor::position()`], keyboard-enhancement queries, OSC
+  color queries, or child-process terminal handoffs beside an active [`EventStream`]. Route those
+  operations through the terminal owner, or stop the stream before handing the terminal to something
+  else.
+- **Frames triggered by time or by single events.** The current [`async-github` example] and
+  [`simple-async` template] use a fixed draw interval because that keeps the example compact. The
+  [`event-driven-async` template] wraps crossterm events, ticks, and app events in one event
+  channel, but an app based on it still needs to decide when to drain, coalesce, and draw. In a
+  larger app, fixed intervals and one-event-per-frame loops can hide lag: bursty input, process
+  output, and resize events queue up while each stale frame is being written. Add a dirty flag,
+  drain currently available work before drawing, and coalesce repeated redraw requests.
+- **Shared state as hidden event flow.** The [`async-github` example] uses [`Arc`][`std::sync::Arc`]
+  and [`RwLock`][`std::sync::RwLock`] for a one-shot background fetcher, and it says more complex
+  scenarios may need channels or other synchronization. If that shape grows into frequent refreshes,
+  avoid holding a contended lock during render, avoid letting background tasks mutate widget state
+  that the UI also mutates, and guard stale results with a generation or request id. For many apps,
+  a worker message that carries a snapshot is easier to reason about than shared mutable UI state.
+- **No backpressure or shutdown policy.** Templates often use unbounded channels and short
+  cancellation sketches because they are small. Real producers can outpace the terminal, and
+  terminal lifecycle bugs often appear during exit, suspend, resume, panic recovery, or child TUI
+  handoff. Use bounded channels where rate matters, define what gets dropped or replaced, and make
+  the terminal owner stop event reading before it restores or hands off the terminal.
+
+These are not reasons to discard older examples. They are the rules to apply when an app based on
+those examples starts doing real async work: keep one terminal owner, keep [`Terminal::draw`] fast,
+drain bursts before drawing, and make background work cross the boundary as application messages.
+
+## Examples and templates
+
+The examples and templates below are source material, not verdicts. Some are Ratatui applications;
+some are Crossterm-based TUIs; [`Helix`] and [`Termina`] are adjacent terminal projects whose event
+and render models overlap with the same problems. Read each source in two passes: identify the
+mechanism it demonstrates, then audit terminal ownership, blocking, ordering, backpressure, and
+shutdown for your application.
+
+### Small Ratatui examples and templates
+
+The [`async-github` example] shows async data fetching with Ratatui. It keeps rendering in the UI
+loop and fetches GitHub pull requests in a background task, which demonstrates the core async fit:
+network work waits away from the terminal and reports a result back to the UI. The example is
+intentionally small, so treat it as a fetch pattern, not as a complete policy for repeated
+refreshes, cancellation, or backpressure.
+
+The [`simple-async` template] shows a compact Tokio loop that polls [`EventStream`] and updates
+application state. The [`event-driven-async` template] adds a message boundary by wrapping crossterm
+events, ticks, and application events in an mpsc-based event handler. These teach event-stream
+mechanics and message routing. Once an app grows, keep the ownership rule from
+[Async Applications](/concepts/application-patterns/async-applications/): background work can be
+async, but terminal I/O should have one owner.
+
+### Ratatui applications with more machinery
+
+The [`crates-tui`] app shows a fuller async application than the templates. Its [crates-tui app
+loop] awaits one merged event, drains queued actions with [`try_recv`], and draws only for render or
+resize actions. Its [crates-tui event streams] merge ticks, a key-chord refresh timer, a fixed
+render interval, and [`EventStream`]. Its worker paths show message passing around network work:
+[crates-tui search tasks] and [crates-tui summary tasks] spawn async requests, update shared
+[`Arc`][`std::sync::Arc`] / [`Mutex`][`std::sync::Mutex`] state, and send actions back to the UI,
+while [crates-tui detail tasks] keep [`JoinHandle`]s so stale detail requests can be aborted before
+starting a new one. The audit points are the places to harden if the same shape grows: `App::run` is
+still marked [`#[tokio::main]`][`tokio::main`], drawing still blocks the future that owns the
+terminal, the action channel is unbounded, search and summary requests are not guarded by a
+generation id, and the fixed render interval can still hide queued work if drawing becomes
+expensive.
+
+Larger applications expose the machinery that short examples omit: ownership boundaries, burst
+draining, coalescing, backpressure, cancellation, terminal handoffs, and redraw scheduling.
+
+[`Yazi`] shows an async-heavy Ratatui application with explicit cancellation, render flags, and
+queues around the blocking draw boundary. Its [Yazi app loop] uses [`tokio::select!`], drains queued
+application events with [`try_recv`], and schedules rendering from render flags. Its [Yazi terminal
+wrapper] owns terminal setup, sends terminal queries, creates an [`EventStream`], and spawns a task
+to forward terminal events into the application event bus. Background work is split into worker
+classes with cancellation tokens in the [Yazi worker scheduler]. CPU-heavy highlighting uses
+[`spawn_blocking`] and a cancellation ticket in the [Yazi highlighter], while [Yazi preview tasks]
+and [Yazi search tasks] abort stale [`JoinHandle`]s and chunk bursty result streams. The boundary is
+that [Yazi render path] still calls [`Terminal::draw`]; the surrounding machinery keeps that
+blocking operation coordinated.
+
+[`Codex CLI`] is a larger async Ratatui application with explicit terminal boundaries. Its [Codex
+app loop] selects over app messages, active thread events, terminal events, and app-server events.
+Its [Codex event stream] keeps one shared Crossterm stream and can drop and recreate the stream when
+the TUI must relinquish stdin. Its [Codex frame scheduler] coalesces redraw requests before
+notifying the UI loop, and its [Codex terminal probes] run short terminal queries only while the
+event stream is absent or paused. Its [Codex terminal draw path] also makes the blocking draw cost
+visible: autoresize, render, flush, cursor update, and backend flush happen inside the terminal
+owner.
+
+### Blocking selector applications
+
+[`bottom`] shows the synchronous-terminal-owner pattern. Its [bottom startup loop] creates a data
+collection thread, an input thread, and a cleaning thread, then the main loop receives application
+events and draws from one terminal owner. Its [bottom input thread] blocks in Crossterm polling and
+reading, filters key releases, ignores mouse motion, and rate-limits mouse scroll. That shape avoids
+starving a Tokio runtime with [`Terminal::draw`]. The remaining boundary is terminal queries and
+handoffs: input reading and rendering still happen on different threads, and the [bottom update
+branch] converts collected data on the UI thread before drawing.
+
+[`gitui`] shows many blocking event sources feeding one central UI selector. Its [gitui select loop]
+waits on input, Git worker notifications, app notifications, a ticker, a file watcher, and a spinner
+ticker. Its [gitui input thread] shows a concrete terminal handoff pattern: suspend polling while an
+external editor owns the terminal, then resume polling and re-hide the cursor when control returns.
+Its [gitui draw path] resizes before drawing when the app requires a redraw, and its [gitui async
+job] worker keeps only one queued follow-up job while another job is running. The follow-up boundary
+is event batching: the app still has a separate input reader thread and still draws after many
+individual events.
+
+[`bacon`] and [`dua-cli`] show blocking selector designs with producer pressure. Bacon's [bacon app
+loop] selects across timers, file watchers, process output, and user events, while its [bacon
+executor] sleeps through a grace period before starting a command and reads child stdout and stderr
+on blocking threads. Dua's [dua input channel] uses a zero-capacity channel for key events, its [dua
+event loop] selects between terminal input and background traversal events, and its [dua traversal]
+uses a bounded filesystem-walk channel. These sources shape producer behavior before it reaches the
+UI. The limitation is still frame cost: if process output or filesystem results arrive faster than
+the UI can integrate and draw them, the terminal owner can fall behind.
+
+### Async loop and adjacent terminal stacks
+
+[`tokio-console`] shows compact state streaming inside a Tokio loop. Its [tokio-console main loop]
+selects over Crossterm input, instrumentation messages, and a bounded task-details channel, then
+draws after the selected branch updates state. Its [tokio-console detail watcher] uses
+[`tokio::sync::watch`] to stop stale detail streams when the selected task changes. Its
+[tokio-console input module] explicitly notes that supporting blocking input backends would probably
+involve [`spawn_blocking`]. The boundary is the same terminal cost: [`Terminal::draw`] stays in the
+async loop, so expensive frames still block that task.
+
+[`Helix`] and [`Termina`] are not Ratatui applications, but they model the same terminal problems
+directly. Helix's [Helix render path] keeps frame start, autoresize, render, and draw in the
+application loop. Async code calls [request_redraw], which is debounced, and Helix's [diff worker]
+batches document changes, uses [`block_in_place`] for expensive diffing, and coordinates render
+locks and timeouts. Termina's [Termina event enum] matters because it treats keys, resize events,
+focus, paste, CSI, OSC, and DCS responses as one event model instead of pretending terminal replies
+are separate from input. Its [filtered event reader] lets [`poll`][Termina poll] and
+[`read`][Termina read] keep rejected events buffered for later reads, and its [Termina event stream]
+adapts the blocking reader to async by parking a helper thread on the event source.
+
+Read examples as design references, not verdicts. Short examples isolate one teaching point. Larger
+applications show the supporting machinery that teaching examples omit. Nontrivial apps add
+ownership boundaries, burst draining, coalescing, backpressure, cancellation, and terminal handoff
+code because `spawn a task` and [`EventStream`] do not settle those decisions by themselves.
+
+[Codex app loop]:
+  https://github.com/openai/codex/blob/98d28aab54ed86714901b6619400598598876dd0/codex-rs/tui/src/app.rs#L1113-L1216
+[Codex event stream]:
+  https://github.com/openai/codex/blob/98d28aab54ed86714901b6619400598598876dd0/codex-rs/tui/src/tui/event_stream.rs#L1-L18
+[Codex frame scheduler]:
+  https://github.com/openai/codex/blob/98d28aab54ed86714901b6619400598598876dd0/codex-rs/tui/src/tui/frame_requester.rs#L1-L128
+[Codex terminal draw path]:
+  https://github.com/openai/codex/blob/98d28aab54ed86714901b6619400598598876dd0/codex-rs/tui/src/custom_terminal.rs#L334-L438
+[Codex terminal probes]:
+  https://github.com/openai/codex/blob/98d28aab54ed86714901b6619400598598876dd0/codex-rs/tui/src/terminal_probe.rs#L1-L18
+[Helix render path]:
+  https://github.com/helix-editor/helix/blob/a2c9f44a564592257334ce0cec2fc904412173b5/helix-term/src/application.rs#L261-L292
+[Termina event enum]:
+  https://github.com/helix-editor/termina/blob/4efcdc689e5abfe27e165a4840a1d612bc52758c/src/event.rs#L1-L117
+[Termina event stream]:
+  https://github.com/helix-editor/termina/blob/4efcdc689e5abfe27e165a4840a1d612bc52758c/src/event/stream.rs#L1-L156
+[Termina poll]:
+  https://github.com/helix-editor/termina/blob/4efcdc689e5abfe27e165a4840a1d612bc52758c/src/event/reader.rs#L116-L133
+[Termina read]:
+  https://github.com/helix-editor/termina/blob/4efcdc689e5abfe27e165a4840a1d612bc52758c/src/event/reader.rs#L138-L149
+[Yazi app loop]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-fm/src/app/app.rs#L34-L93
+[Yazi highlighter]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-core/src/highlighter.rs#L28-L144
+[Yazi preview tasks]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-core/src/tab/preview.rs#L26-L85
+[Yazi render path]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-fm/src/app/render.rs#L16-L68
+[Yazi search tasks]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-actor/src/mgr/search.rs#L51-L99
+[Yazi terminal wrapper]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-tui/src/raterm.rs#L35-L142
+[Yazi worker scheduler]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-scheduler/src/worker.rs#L24-L294
+[`Codex CLI`]:
+  https://github.com/openai/codex/tree/98d28aab54ed86714901b6619400598598876dd0/codex-rs/tui
+[`EventStream`]: https://docs.rs/crossterm/latest/crossterm/event/struct.EventStream.html
+[`Helix`]: https://github.com/helix-editor/helix
+[`JoinHandle`]: https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html
+[`Termina`]: https://github.com/helix-editor/termina
+[`Terminal::draw`]: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html#method.draw
+[`Yazi`]: https://github.com/sxyazi/yazi
+[`async-github` example]:
+  https://github.com/ratatui/ratatui/tree/d301c75f40854718374838ea3d6d704136b62e06/examples/apps/async-github
+[`async-template`]: https://github.com/ratatui/async-template
+[`bacon`]: https://github.com/Canop/bacon
+[`block_in_place`]: https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html
+[`bottom`]: https://github.com/ClementTsang/bottom
+[`crates-tui`]: https://github.com/ratatui/crates-tui
+[`crossterm::event::poll`]: https://docs.rs/crossterm/latest/crossterm/event/fn.poll.html
+[`crossterm::event::read`]: https://docs.rs/crossterm/latest/crossterm/event/fn.read.html
+[`cursor::position()`]: https://docs.rs/crossterm/latest/crossterm/cursor/fn.position.html
+[`dua-cli`]: https://github.com/Byron/dua-cli
+[`event-driven-async` template]:
+  https://github.com/ratatui/templates/tree/cd2b97b11fd4dcc40607e8ab3f73bc09c12c6a4f/event-driven-async
+[`gitui`]: https://github.com/extrawurst/gitui
+[`simple-async` template]:
+  https://github.com/ratatui/templates/tree/cd2b97b11fd4dcc40607e8ab3f73bc09c12c6a4f/simple-async
+[`spawn_blocking`]: https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html
+[`std::sync::Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
+[`std::sync::Mutex`]: https://doc.rust-lang.org/std/sync/struct.Mutex.html
+[`std::sync::RwLock`]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
+[`tokio-console`]:
+  https://github.com/tokio-rs/console/tree/59e23edf17b0e42e87e315bfc9cbb8a6ba2f401f/tokio-console
+[`tokio::main`]: https://docs.rs/tokio/latest/tokio/attr.main.html
+[`tokio::select!`]: https://docs.rs/tokio/latest/tokio/macro.select.html
+[`tokio::sync::watch`]: https://docs.rs/tokio/latest/tokio/sync/watch/index.html
+[`try_recv`]:
+  https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.UnboundedReceiver.html#method.try_recv
+[bacon app loop]:
+  https://github.com/Canop/bacon/blob/70d8951293501f4aaa1a8adc51f0de4bb70c1501/src/tui/app.rs#L130-L245
+[bacon executor]:
+  https://github.com/Canop/bacon/blob/70d8951293501f4aaa1a8adc51f0de4bb70c1501/src/exec/executor.rs#L112-L190
+[bottom input thread]:
+  https://github.com/ClementTsang/bottom/blob/e61385b77c0790b2328456b64e66f9684f299c74/src/lib.rs#L419-L482
+[bottom startup loop]:
+  https://github.com/ClementTsang/bottom/blob/e61385b77c0790b2328456b64e66f9684f299c74/src/bin/main.rs#L95-L189
+[bottom update branch]:
+  https://github.com/ClementTsang/bottom/blob/e61385b77c0790b2328456b64e66f9684f299c74/src/bin/main.rs#L201-L260
+[crates-tui app loop]:
+  https://github.com/ratatui/crates-tui/blob/e1be774ae75fe9711fa13ba808c87e52db98d251/src/app.rs#L120-L135
+[crates-tui detail tasks]:
+  https://github.com/ratatui/crates-tui/blob/e1be774ae75fe9711fa13ba808c87e52db98d251/src/widgets/search_page.rs#L237-L352
+[crates-tui event streams]:
+  https://github.com/ratatui/crates-tui/blob/e1be774ae75fe9711fa13ba808c87e52db98d251/src/events.rs#L42-L80
+[crates-tui search tasks]:
+  https://github.com/ratatui/crates-tui/blob/e1be774ae75fe9711fa13ba808c87e52db98d251/src/widgets/search_page.rs#L284-L294
+[crates-tui summary tasks]:
+  https://github.com/ratatui/crates-tui/blob/e1be774ae75fe9711fa13ba808c87e52db98d251/src/widgets/summary.rs#L164-L176
+[diff worker]:
+  https://github.com/helix-editor/helix/blob/a2c9f44a564592257334ce0cec2fc904412173b5/helix-vcs/src/diff/worker.rs
+[dua event loop]:
+  https://github.com/Byron/dua-cli/blob/e5b1e89afe554430789d228d8c32f5aa12930a7f/src/interactive/app/eventloop.rs#L104-L194
+[dua input channel]:
+  https://github.com/Byron/dua-cli/blob/e5b1e89afe554430789d228d8c32f5aa12930a7f/src/interactive/app/input.rs#L17-L31
+[dua traversal]:
+  https://github.com/Byron/dua-cli/blob/e5b1e89afe554430789d228d8c32f5aa12930a7f/src/traverse.rs#L225-L295
+[filtered event reader]:
+  https://github.com/helix-editor/termina/blob/4efcdc689e5abfe27e165a4840a1d612bc52758c/src/event/reader.rs
+[gitui async job]:
+  https://github.com/extrawurst/gitui/blob/ee1bcd1eb344ba69bbc301f5b71db8030470e18b/asyncgit/src/asyncjob/mod.rs#L111-L155
+[gitui draw path]:
+  https://github.com/extrawurst/gitui/blob/ee1bcd1eb344ba69bbc301f5b71db8030470e18b/src/main.rs#L303-L315
+[gitui input thread]:
+  https://github.com/extrawurst/gitui/blob/ee1bcd1eb344ba69bbc301f5b71db8030470e18b/src/input.rs#L40-L145
+[gitui select loop]:
+  https://github.com/extrawurst/gitui/blob/ee1bcd1eb344ba69bbc301f5b71db8030470e18b/src/main.rs#L217-L279
+[request_redraw]:
+  https://github.com/helix-editor/helix/blob/a2c9f44a564592257334ce0cec2fc904412173b5/helix-event/src/redraw.rs
+[tokio-console detail watcher]:
+  https://github.com/tokio-rs/console/blob/59e23edf17b0e42e87e315bfc9cbb8a6ba2f401f/tokio-console/src/main.rs#L206-L249
+[tokio-console input module]:
+  https://github.com/tokio-rs/console/blob/59e23edf17b0e42e87e315bfc9cbb8a6ba2f401f/tokio-console/src/input.rs#L1-L4
+[tokio-console main loop]:
+  https://github.com/tokio-rs/console/blob/59e23edf17b0e42e87e315bfc9cbb8a6ba2f401f/tokio-console/src/main.rs#L60-L143

--- a/src/content/docs/concepts/application-patterns/async-applications.md
+++ b/src/content/docs/concepts/application-patterns/async-applications.md
@@ -1,0 +1,1138 @@
+---
+title: Async Applications
+sidebar:
+  order: 4
+---
+
+Async fits Ratatui where the application waits for work that is not terminal rendering. Use Tokio or
+another runtime for network requests, timers, child process output, file work, and background
+computation. Keep terminal input and rendering as one owned UI boundary, then send application
+messages across that boundary.
+
+This page is for applications that combine Ratatui with Tokio, background workers, child processes,
+file watchers, terminal probes, or long-running work. If the application is small and synchronous,
+the normal event loop examples are still enough.
+
+Ratatui renders frames. It does not install an event loop or read keyboard, mouse, paste, focus, and
+resize events for the application. Most examples use crossterm for terminal events.
+
+Terminal input and terminal output do not become async in the same way. On the output side,
+[`Terminal::draw`] is still a blocking render-and-write operation: Ratatui builds a frame, writes
+the diff through the backend, and flushes the writer. On the input side, Crossterm's [`EventStream`]
+adapts terminal reads to a [`Stream`][`futures_core::Stream`], but underneath it is the same shared
+blocking event reader, woken by a helper thread when input is ready; the source-level details are in
+[Crossterm queries share one reader](#crossterm-queries-share-one-reader). Only the input side is
+async-shaped, and only as a notification boundary around blocking terminal reads. This distinction
+is the source of many mistaken designs: `await` can let other futures run while waiting for the next
+event, but it does not make drawing non-blocking, make terminal query replies separate from input,
+or make multiple terminal readers safe.
+
+## TL;DR
+
+Start with the smallest shape that keeps terminal ownership clear:
+
+| Situation                                   | Start with                          |
+| ------------------------------------------- | ----------------------------------- |
+| Timers or a few requests                    | Single async UI task                |
+| Background work, simple terminal behavior   | Main-thread sync owner with workers |
+| Child TUIs, probes, inline viewport, resume | Dedicated terminal actor or thread  |
+| Progress, status, or latest-value snapshots | `watch` or latest-value state       |
+| Ordered events                              | Bounded `mpsc`                      |
+| Search, completion, or preview results      | Generation-tagged messages          |
+| Render, input, process, or watcher bursts   | Dirty flag and redraw scheduler     |
+
+Then apply these rules. The rest of the page explains, derives, and cites each one:
+
+- **Pick one terminal owner.** One task or thread should read terminal events, call
+  [`Terminal::draw`], enter and leave raw mode, switch alternate screens, and run terminal queries.
+  Everything else sends the owner application messages — never terminal bytes, [`println!`] calls,
+  or stdin reads.
+- **Do not mix event readers.** Use [`EventStream`] or use [`crossterm::event::poll`] /
+  [`crossterm::event::read`] from one owner; do not combine them.
+- **Treat drawing as blocking I/O.** [`Terminal::draw`] renders, writes terminal bytes, and flushes
+  the backend. Async code around it does not make that work non-blocking.
+- **Treat terminal query replies as input.** Cursor-position, color, keyboard-support, and
+  window-size replies arrive through the terminal input stream and can race with keys.
+- **Keep slow awaits and CPU-heavy work off the UI loop.** Network requests, child processes, file
+  watchers, and timers report back with application messages. Parsing, searching, highlighting,
+  diffing, and decoding run on [`spawn_blocking`], [Rayon], or worker threads.
+- **Use bounded channels by default.** Every producer needs a backpressure policy; unbounded queues
+  hide lag until the UI is already behind. Decide whether producers wait, drop stale messages,
+  coalesce updates, or report overload.
+- **Drain bursts, then draw once.** Read all immediately available terminal events and worker
+  messages, coalesce them with a dirty flag, frame budget, or frame scheduler, and do not make one
+  event equal one frame.
+- **Cancel or tag stale work.** Search, completion, preview, and detail tasks should not update the
+  UI after the user has moved on.
+- **Serialize handoffs.** Pause the parent event reader, restore terminal modes, run the child TUI
+  or shell command, re-enter terminal modes, flush stale input, then resume events.
+
+## Where async fits
+
+A synchronous TUI loop usually waits for one terminal event, updates state, and draws:
+
+```rust
+loop {
+    let event = crossterm::event::read()?;
+    app.handle_terminal_event(event);
+    terminal.draw(|frame| app.render(frame))?;
+}
+```
+
+That loop is easy to reason about because only one thing happens at a time. It also freezes whenever
+the loop waits for something slow. If `handle_terminal_event` performs an HTTP request, waits for a
+child process, or runs an expensive search before returning, the application cannot read the next
+key, handle a resize, or redraw progress.
+
+Async changes where the waiting happens. The render step should still be a synchronous
+state-to-frame operation. Slow work runs somewhere else, then reports back to the UI owner through
+messages, shared state, or another explicit handoff.
+
+## Recommended shapes
+
+Async Ratatui applications have two separate design choices:
+
+1. Pick the terminal owner. This decides which code path may read terminal events, call
+   [`Terminal::draw`], enter or leave raw mode, and run terminal queries.
+1. Pick the background coordination patterns. This decides how network work, CPU work, child
+   processes, file watchers, timers, and caches report back to the terminal owner.
+
+:::tip[Composition rule]
+
+Pick exactly one terminal owner. Combine as many background coordination patterns as the app needs.
+A larger app might keep the terminal on a dedicated thread, receive worker messages over bounded
+channels, use [`watch`][`tokio::sync::watch`] for progress snapshots, and route redraw requests
+through a frame scheduler.
+
+:::
+
+The first three shapes decide who touches Crossterm and Ratatui; their implementations are below.
+The remaining shapes are expanded in [Coordination patterns](#coordination-patterns) after the
+blocking and terminal-ownership constraints are clear.
+
+- **Main-thread synchronous terminal owner with async workers.** Benefit: terminal invariants stay
+  local; async tasks wait on network, file, timer, child-process, or CPU work away from the
+  terminal. Tradeoff: this shape is less common in public Ratatui examples, needs explicit runtime
+  and channel wiring, and still needs polling, draining, and backpressure so worker results do not
+  sit behind keyboard bursts.
+- **Single async UI task.** Benefit: one compact [`tokio::select!`] loop can own [`EventStream`],
+  timers, worker messages, terminal queries, and drawing. Tradeoff: [`Terminal::draw`] still blocks
+  the runtime worker or current-thread runtime that is polling the UI task, and later features can
+  accidentally add a second terminal reader.
+- **Dedicated terminal actor or thread.** Benefit: terminal I/O is isolated from the async executor,
+  and raw mode, events, drawing, handoffs, and terminal probes have one serialized owner. Tradeoff:
+  the app now owns a mailbox protocol, shutdown behavior, backpressure policy, and sync/async
+  boundary.
+- **Message-passing workers.** Benefit: bounded [`tokio::sync::mpsc`] channels carry ordered
+  application events such as request completion, process output, file watcher changes, and failures.
+  Tradeoff: every producer needs a queue policy; unbounded channels and one-message-one-draw loops
+  turn bursts into input lag.
+- **Latest-value state.** Benefit: shared state or [`tokio::sync::watch`] avoids queue growth when
+  replacement is correct, such as progress, status text, cache snapshots, or the latest search
+  request. Tradeoff: this shape is wrong when every transition matters, and it can hide lock
+  contention or stale-result bugs unless the UI snapshots state before drawing.
+- **Resource actors.** Benefit: a long-lived terminal, connection, child process, search cache, or
+  preview worker gets one owner, a mailbox, and explicit command/reply paths. Tradeoff: lifecycle,
+  cancellation, mailbox saturation, and channel cycles become part of the application design.
+- **Redraw scheduling.** Benefit: a dirty flag, frame budget, or frame scheduler coalesces many
+  "please draw" notifications into one frame. Tradeoff: stale redraw notifications can schedule
+  redundant frames, and an overly coarse frame policy can hide that producers are outpacing the UI.
+
+The examples on this page share these dependencies. Crossterm's `event-stream` cargo feature is
+required for [`EventStream`]; the synchronous-owner shape does not need it. Tokio's `macros` feature
+provides [`tokio::select!`] and [`#[tokio::main]`][`tokio::main`]:
+
+```toml title="Cargo.toml"
+{{ #include @code/concepts/async-applications/Cargo.toml:dependencies }}
+```
+
+### Main-thread synchronous owner with async workers
+
+The correctness-oriented default is to keep the terminal owner synchronous on the main thread and
+let the async runtime own the background work. The terminal owner owns raw mode, crossterm event
+reads, Ratatui drawing, and terminal queries. Async tasks send it messages:
+
+```rust
+{{ #include @code/concepts/async-applications/src/main.rs:main_thread_owner }}
+```
+
+This shape keeps slow awaits outside the draw closure and outside the terminal event reader. The
+worker task awaits the network or file operation and reports back through a channel. The terminal
+owner drains messages and terminal events, updates state, and draws only when the state is dirty and
+the frame budget allows it. Both drain loops are capped at `MAX_EVENTS_PER_TURN` so a paste, macro,
+or worker burst cannot starve drawing; [Bound the drain](#bound-the-drain) explains that budget.
+
+The worker's `let _ = ui_tx.send(...)` is deliberate. When the UI loop exits, the receiver drops and
+later sends fail with a closed-channel error. That failure is the worker's shutdown signal, not an
+error worth reporting.
+
+Keep the channel payloads at the application layer. A worker should not send "write these terminal
+bytes" or "read cursor position" requests unless the terminal owner is explicitly an actor that owns
+those operations. Most workers should send facts the UI can apply to its state:
+
+```rust title="application messages"
+{{ #include @code/concepts/async-applications/src/main.rs:messages }}
+```
+
+### Single async UI task
+
+Crossterm's [`EventStream`] exposes events as a [`Stream`][`futures_core::Stream`], so smaller
+examples often put terminal events, timers, worker messages, and shutdown signals in one
+[`tokio::select!`] loop. Tokio's [`select!` tutorial] explains the general pattern. In a TUI, that
+is a valid compact shape for applications that can tolerate terminal work blocking one runtime
+worker, but it is not a different terminal model. The async task that calls [`Terminal::draw`] is
+still performing synchronous terminal I/O:
+
+```rust
+{{ #include @code/concepts/async-applications/src/single_task.rs:single_task }}
+```
+
+If you use this compact shape, keep all terminal event reading, drawing, and terminal queries inside
+that one task. Do not add another task or thread that reads from the terminal or sends terminal
+queries while [`EventStream`] is active. This example draws dirty frames on a tick so input and
+worker bursts can collapse into one render; animations can mark the app dirty from a timer when they
+need continuous frames.
+
+Handle the stream's `Err` and `None` arms explicitly. A pattern branch like
+`Some(Ok(event)) = terminal_events.next()` silently disables itself when the stream errors or ends,
+leaving a loop that still processes worker messages and renders but is permanently deaf to input — a
+quiet failure with no diagnostic. Two smaller details of the tick branch: the `if dirty`
+precondition disables it while there is nothing to draw, but [`Interval`] deadlines keep passing on
+the clock, so an app that has been idle for longer than one frame interval draws immediately once it
+becomes dirty ([`MissedTickBehavior`] controls how those missed deadlines are delivered). An app
+that becomes dirty again right after a draw still waits for the next deadline, which is what caps
+the frame rate.
+
+Also remember what [`tokio::select!`] does and does not promise. Its branches run concurrently on
+the current task, not in parallel, so a blocking draw or terminal query in one branch stops the
+other branches from making progress. When one branch completes, the other branch futures are
+cancelled by being dropped. That is fine for cancellation-safe receives such as
+[`mpsc::Receiver::recv`] and stream [`next`][`StreamExt::next`]. Keep partially completed I/O and
+terminal protocol reads behind an owner that can finish, buffer, or abort the operation
+deliberately.
+
+### Dedicated terminal owner
+
+When the main-thread owner becomes too crowded, move terminal ownership behind an explicit actor or
+dedicated blocking thread. This is the larger-app version of the same ownership rule: one serialized
+owner still controls raw mode, the backend, terminal event reading, Ratatui drawing, and terminal
+queries. Async tasks send application messages to it over channels, and the terminal owner sends
+user actions or shutdown messages back.
+
+This shape treats Ratatui and Crossterm as synchronous terminal code:
+
+- the async runtime handles network requests, timers, child processes, and other background work
+- the terminal thread blocks in [`crossterm::event::poll`] / [`crossterm::event::read`] or in
+  [`Terminal::draw`]
+- messages crossing the boundary are application events, not raw terminal reads or writes
+
+This protects the async executor from slow terminal writes, but it does not remove the terminal
+protocol constraints. The terminal owner should still be the only code path that calls
+[`EventStream`] in an async-owner design, [`read`][`crossterm::event::read`] /
+[`poll`][`crossterm::event::poll`] in a blocking-owner design, [`cursor::position()`],
+[`supports_keyboard_enhancement()`], inline viewport creation, or any other operation that sends a
+terminal query and waits for a reply. If the application temporarily hands the terminal to a child
+TUI such as Vim, stop reading events first, restore the terminal, run the child, then re-enter the
+TUI afterward.
+
+[`spawn_blocking`] can bridge from an async `main` into blocking terminal code, but it is not a
+terminal ownership model by itself. For a long-lived terminal loop, an explicit main-thread or
+dedicated-thread owner keeps terminal ownership easier to audit than scattered blocking terminal
+calls across unrelated [`spawn_blocking`] closures.
+
+A full handoff usually has more than one step: pause or drop the event stream, leave alternate
+screen if necessary, restore raw mode and keyboard reporting, run the child process, re-enable the
+TUI's terminal modes, flush or reconcile buffered input, and only then resume event reading.
+Suspend/resume has the same shape. The [Codex suspend fix] pauses input polling while suspended,
+re-synchronizes raw mode after `fg`, probes the post-resume cursor position while the event reader
+is paused, and flushes buffered input before resuming normal events.
+
+```rust title="external program handoff"
+fn run_external_editor(tui: &mut Tui, path: &Path) -> color_eyre::Result<()> {
+    tui.pause_terminal_events()?;
+    ratatui::restore();
+
+    let status = std::process::Command::new("vim").arg(path).status()?;
+
+    tui.replace_terminal(ratatui::init());
+    tui.flush_stale_input()?;
+    tui.resume_terminal_events()?;
+    tui.request_redraw();
+
+    if !status.success() {
+        tui.push_error(format!("editor exited with {status}"));
+    }
+
+    Ok(())
+}
+```
+
+The method names in this sketch are application-specific. Preserve the ordering: stop the parent
+reader before the child owns the terminal, and do not resume parent events until the TUI has
+re-entered and reconciled buffered input.
+
+## Blocking boundaries
+
+Async does not make [`Terminal::draw`] non-blocking. It changes how the program waits between render
+steps. Tokio tasks are cooperatively scheduled: a task must reach an `.await` before the runtime can
+swap it out for other work. If an async TUI task spends a long time drawing, parsing, holding a
+contended lock, or calling blocking terminal APIs, the executor cannot run other futures on that
+worker thread during that time. This is the executor-starvation problem described in [Async: What is
+blocking?].
+
+Terminal I/O is only one source of starvation. CPU-heavy parsing, syntax highlighting, diffing,
+fuzzy search, compression, image decoding, and large data transforms have the same shape when they
+run inside an async task without yielding. Tokio's [CPU-bound tasks and blocking code] docs describe
+the general rule: async code runs on core threads, and long-running work without `.await` points
+prevents the runtime from driving other tasks on that thread. If a TUI both draws slowly and runs
+CPU-heavy work on runtime threads, the effects compound: event readers, timers, network responses,
+worker messages, and redraw scheduling all compete for fewer available executor turns.
+
+The top-level [`#[tokio::main]`][`tokio::main`] future is a special case. Tokio's macro docs and
+[Tokio main macro source] say that the async function marked with [`#[tokio::main]`][`tokio::main`]
+does not run as a worker, and the macro expands to a runtime builder followed by
+[`Runtime::block_on`]. The [Tokio multi-thread block_on source] documents that the
+[`Runtime::block_on`] future runs on the current thread, while spawned tasks run on the worker pool.
+This shape runs the UI future on the caller thread, not as a work-stealing worker task:
+
+```rust
+#[tokio::main]
+async fn main() {
+    run_ui().await;
+}
+```
+
+Blocking that future still blocks the UI loop and anything awaited inside it; on a multi-thread
+runtime, separately spawned background tasks can keep running and queue messages. On a
+current-thread runtime, the same blocked thread drives the whole runtime.
+
+Tokio's [Bridging with sync code] guide makes the current-thread case especially explicit: a
+current-thread runtime only runs while [`Runtime::block_on`] is active, and spawned tasks on that
+runtime freeze once `block_on` returns. If a synchronous terminal owner embeds a current-thread
+runtime, use it for bounded async calls where that pause is acceptable. If background tasks must
+keep running while the terminal owner blocks in event reads or drawing, use a multi-thread runtime
+or run the runtime on another thread and communicate with messages.
+
+Spawning the UI loop with [`tokio::spawn`] and awaiting its join handle changes that scheduling
+property: the UI loop becomes a runtime task. That is not automatically a better terminal ownership
+model, because a spawned task may move between worker threads and terminal event/query ordering
+still has to be explicit. If thread identity or handoff ordering matters, prefer an explicit
+main-thread or dedicated-thread terminal owner and communicate with async tasks through messages.
+
+Frame policy controls how often the application crosses the blocking draw boundary. Mostly static
+applications can replace a fixed render interval with a dirty flag or an explicit
+`UiMessage::RenderRequested`. Animations, progress indicators, and streams of child-process output
+may still need a render interval, but they should not redraw once for every input event.
+
+## Terminal ownership
+
+### The UI loop owns the terminal
+
+Keep one part of the program responsible for terminal input and terminal output. That owner can be a
+synchronous loop, a dedicated blocking thread, or a single async task in a compact application. It
+should be the only place that reads terminal events, calls [`Terminal::draw`], enters or leaves raw
+mode, and runs terminal queries that can read from the terminal.
+
+Background tasks should send application messages or update shared state. They should not call
+[`println!`], write directly to the terminal backend, read from stdin, or ask the backend for
+terminal state while the UI loop is active.
+
+The terminal input stream carries more than keys. It also carries paste bytes, mouse events, focus
+events, resize notifications, and replies to terminal queries that the application sent earlier:
+
+```text
+keys, paste, mouse, resize, query replies
+                  |
+                  v
+          terminal input stream
+                  |
+                  v
+          one terminal reader
+
+terminal owner:
+  - reads events
+  - sends terminal queries
+  - receives query replies
+  - draws frames
+```
+
+If one task owns [`EventStream`] while another task calls [`cursor::position()`], the cursor query
+writes `ESC [ 6 n` and waits for a reply on the same input stream the event reader is consuming.
+Whichever reader receives the bytes first decides whether the query succeeds, becomes a normal input
+event, or disappears from the query's point of view.
+
+Raw mode is part of that ownership boundary. Crossterm's [terminal module] documents raw mode as a
+set of terminal-driver changes: input is not echoed, input is delivered without line buffering,
+special keys such as `Ctrl+C` are not processed by the terminal driver, and newline handling changes
+enough that [`println!`] is the wrong output primitive while raw mode is active. Restore or hand off
+those modes through the same owner that reads input and draws frames. Treat alternate-screen entry
+and exit the same way: the terminal module describes alternate and main screen buffers as separate
+terminal surfaces, so child TUI handoffs should leave and re-enter them through the terminal owner.
+
+Crossterm's [event module] states the ownership rule: use [`read`][`crossterm::event::read`] and
+[`poll`][`crossterm::event::poll`] together on the same thread, or use [`EventStream`]; do not call
+[`read`][`crossterm::event::read`] and [`poll`][`crossterm::event::poll`] from different threads,
+and do not combine them with [`EventStream`].
+
+[`EventStream`] deserves the same ownership rule. It is convenient in [`tokio::select!`], but it
+does not create an independent Tokio-owned terminal. Large applications that temporarily hand the
+terminal to another process should drop and recreate the stream instead of merely stopping their own
+polling. The [Codex EventStream refactor] was made for that reason: crossterm's event stream can
+continue to read stdin while another process or terminal query expects to own those bytes.
+
+### Ratatui still calls the backend
+
+[`Terminal::draw`] is synchronous, but it is not just a call to your render function.
+[`Terminal::try_draw` source] shows the shape: [`Terminal::draw`] calls [`Terminal::autoresize`],
+creates a [`Frame`], runs your render callback, diffs the current and previous buffers, writes
+changed cells with [`Backend::draw`], applies cursor visibility and position, swaps buffers, and
+calls [`Backend::flush`].
+
+Keep two Crossterm paths separate:
+
+- A normal fullscreen draw checks terminal size and writes output. [`Terminal::autoresize`] calls
+  [`Backend::size`]. With Crossterm, [`CrosstermBackend::size` source] calls
+  [`crossterm::terminal::size()`], whose [`crossterm Unix size source`] opens `/dev/tty` when it can
+  and falls back to stdout for the `TIOCGWINSZ` size query. Ratatui then computes the buffer diff,
+  calls [`Backend::draw`], and flushes the backend writer. This is synchronous I/O and can block,
+  but it does not normally consume terminal input bytes.
+- Inline viewports add a terminal input/output round trip. [`Terminal::draw`] calls
+  [`Terminal::autoresize`], which may call [`Terminal::resize` source], which calls
+  [`compute_inline_size` source], which calls [`Backend::get_cursor_position`]. With Crossterm,
+  [`CrosstermBackend::get_cursor_position` source] calls [`crossterm cursor position source`]. On
+  Unix, that function drains stale cursor-position replies, writes `ESC [ 6 n` to stdout, flushes,
+  and then polls and reads Crossterm's internal event reader for up to two seconds waiting for the
+  reply. This is both terminal output and terminal input.
+
+[`Terminal::clear` source] also snapshots the cursor with [`Backend::get_cursor_position`] before
+clearing and restoring the cursor. Treat [`Terminal::clear`] like inline viewport setup: call it
+only from the terminal owner.
+
+Those backend calls are expected; coordinate them through the [`Terminal`] owner. Application code
+should avoid adding competing backend or crossterm calls from unrelated tasks. Backend
+implementations can differ, so the rule is about ownership of backend operations rather than a claim
+that every backend reads terminal replies in the same way. Size checks, cursor-position queries,
+line reservation, drawing, and flushing are still synchronous backend calls, and any backend query
+that writes to the terminal and waits for a reply should run under the same owner as event reading.
+
+Viewport choice matters:
+
+- Fullscreen viewports query [`Backend::size`] during [`Terminal::draw`] and resize Ratatui's
+  buffers when it changes. This path uses [`Backend::size`], not [`Backend::window_size`].
+- Fixed viewports do not autoresize.
+- Inline viewports are anchored to the terminal cursor row. Creating or resizing an inline viewport
+  calls [`Backend::get_cursor_position`] and may call [`Backend::append_lines`] to reserve vertical
+  space.
+
+[`Backend::window_size`] is a separate backend API for callers that need both cell dimensions and
+pixel dimensions. If your application uses it, keep that query under the same terminal owner.
+
+Use a narrow rule: not every fullscreen draw reads stdin, but every [`Terminal::draw`] is a blocking
+terminal operation. With inline viewports or cursor-preserving APIs, the call path can also read
+terminal replies through Crossterm's event reader. If you use [`Viewport::Inline`], keep inline
+creation, drawing, resizing, clearing, and event reading under the same terminal owner.
+
+### Terminal I/O has stateful round trips
+
+Terminal input and output are connected by escape sequences. Some operations write a query to the
+terminal and then wait for a reply in the input stream. That is different from a normal HTTP request
+or file read because keyboard input, mouse events, paste events, resize events, and terminal query
+replies can all arrive through the same event path.
+
+The Windows [Console Virtual Terminal Sequences] documentation states this directly: control
+sequences written to output may produce input-stream responses. XTerm's [control
+sequences][XTerm control sequences] are the reference for many of the CSI, OSC, and DCS queries used
+by terminal emulators; for example, status-string and color queries are modeled as terminal
+responses, not as a separate side channel.
+
+#### Crossterm queries share one reader
+
+Crossterm documents this for several Unix terminal queries. [`cursor::position()`] can block or time
+out while [`crossterm::event::read`] or [`crossterm::event::poll`] is being called. The same caveat
+appears on [`supports_keyboard_enhancement()`]. Crossterm also keeps one internal event reader.
+[`EventStream` source] uses a helper operating-system thread that waits on that reader and wakes the
+async stream; [`crossterm internal event reader source`] stores the reader behind one static mutex.
+It is not independent terminal I/O owned by Tokio.
+
+#### Tokio stdio is not terminal ownership
+
+Tokio's stdio APIs follow a similar boundary. [`tokio::io::stdin`] fits non-interactive input such
+as a pipe; Tokio implements it as an ordinary blocking read on a separate thread, cannot cancel the
+read, and warns that runtime shutdown can hang until the user presses enter. For interactive input,
+Tokio recommends a dedicated thread that uses blocking I/O directly. [`tokio::io::stdout()`] and
+[`tokio::io::Stdout`] also need care: concurrent writes can interleave, and repeatedly creating
+stdout handles in a loop can mangle output because writes may be handled by different blocking
+threads.
+
+Foreground and background color queries are in the same class. OSC 10/11 color queries write a
+request to the terminal and receive the answer through terminal input. The [Codex color-query patch]
+fixed bugs where foreground/background color queries fought with other input; pasted image paths
+could be split and misclassified because the query reader and the normal input path were both trying
+to consume terminal bytes.
+
+That means [`stdin.lock()`][`Stdin::lock`] is not a synchronization boundary for terminal protocols.
+If one task is waiting for [`EventStream`] events while another library writes an ANSI query and
+waits for a reply, the reply can be consumed or buffered by the wrong reader. This is the problem
+reported in [crossterm/crossterm#1039] and the broader query design issue in
+[crossterm/crossterm#763].
+
+#### Stdio and tty handles differ
+
+Stdio and the controlling terminal are also different file handles. On Unix, Crossterm's event
+reader uses stdin when stdin is a TTY and falls back to `/dev/tty` otherwise. Terminal size checks
+open `/dev/tty` and fall back to stdout. [`cursor::position()`] writes its query to stdout and waits
+for the reply through Crossterm's event reader, so redirecting stdout can make cursor-position
+queries fail or time out; see [crossterm/crossterm#919]. Keeping a TUI on stderr reserves stdout for
+final CLI output, but it does not make every terminal query safe.
+
+Use [`std::io::IsTerminal`] for the CLI boundary: it tells whether a stdio descriptor or handle is a
+terminal/tty. The [Rust CLI book] uses that distinction to choose human or machine output and to
+handle `-` as piped stdin only when stdin is not interactive. That check helps decide whether an app
+is reading a pipe or talking to a user, but it does not serialize terminal protocol reads after the
+TUI has started.
+
+Ratatui has hit this class of bug. In [ratatui/ratatui#2483], a resize redraw path called
+[`crossterm::cursor::position()`]. That cursor position report writes a query to stdout and waits
+for a reply from stdin. Applications that were already reading stdin for input could race that
+reply, which made rendering fail with a cursor-position timeout. [ratatui/ratatui#2485] changed
+resize handling so fullscreen resize no longer calls
+[`get_cursor_position()`][`Backend::get_cursor_position`]. Inline viewports still need a
+cursor-position query because their area is defined relative to the current cursor row.
+
+#### Startup probes need an exclusive window
+
+Run startup terminal queries before the normal event stream starts, or route them through the same
+terminal owner that reads events. Keyboard-enhancement detection, primary device attributes,
+cursor-position reports, foreground/background color queries, pixel-size queries, and
+terminal-multiplexer probe sequences all send bytes to the terminal and then expect specific bytes
+back. If the event reader is already consuming input, the query reply is just another input sequence
+that can be misclassified, buffered behind unrelated events, or consumed by the wrong code path. Use
+timeouts for those replies and decide how the application should continue when a terminal or
+multiplexer does not answer.
+
+If you implement direct tty probes for startup or resume, treat the probe window as exclusive. A
+probe that reads raw bytes while looking for one reply may also consume unrelated keyboard, paste,
+focus, or resize input. Either buffer and replay rejected bytes under the same terminal owner, or
+make the probe short enough that discarding unrelated buffered input is an acceptable tradeoff.
+Codex's [bounded terminal probes] use a 100 ms default timeout, batch cursor-position, keyboard, and
+OSC 10/11 color queries under one deadline, and cache `None` when optional replies are missing,
+malformed, or partial.
+
+#### Filtering belongs inside the owner
+
+Filtering terminal input can help, but it is not a replacement for ownership. A terminal reader can
+wait for a specific protocol reply while buffering rejected key, mouse, paste, or resize events for
+later. That is still one shared terminal reader. It does not make it safe for unrelated tasks to run
+their own filtered reads, and it may not preserve exact ordering of rejected events across multiple
+filtered reads. Keep filtered reads, terminal queries, and the normal event stream under the same
+owner.
+
+Termina's [filtered event reader] shows that design. Its [`poll`][Termina poll] and
+[`read`][Termina read] methods take filters and retain rejected events so later reads can observe
+them. The buffering lives inside the shared terminal reader, not in independent tasks racing to read
+from stdin or `/dev/tty`.
+
+Rule: do not create independent terminal readers and writers. Let the UI loop own terminal events
+and drawing. If another task needs to affect the interface, send a message to the UI loop.
+
+## Failure modes
+
+These failures have shown up in real Ratatui, Crossterm, and terminal UI applications. They are the
+reason this page treats terminal ownership as a concrete rule rather than an abstract preference.
+
+### Query replies reach the wrong reader
+
+#### Cursor-position timeout during resize
+
+**Symptom:** Rendering fails with `The cursor position could not be read within a normal duration`.
+
+**Cause:** In [ratatui/ratatui#2483], a resize redraw path called [`crossterm::cursor::position()`]
+while the application also had a thread reading stdin for input. The cursor-position query wrote
+`ESC [ 6 n` and waited for the terminal's reply, but the normal input reader could race that reply.
+
+**Fix:** [ratatui/ratatui#2485] fixed the fullscreen resize path by clearing without calling
+[`get_cursor_position()`][`Backend::get_cursor_position`]. Explicit [`Terminal::clear`] calls and
+inline viewport setup still need the same terminal-owner rule because they can still ask for the
+cursor position.
+
+#### Cursor-position queries fail when stdout is redirected
+
+**Symptom:** [`crossterm::cursor::position()`] times out under `cargo run > output`, and terminal
+response bytes can be written into the redirected output file.
+
+**Cause:** [crossterm/crossterm#919] shows a query path that writes to stdout and reads through
+Crossterm's event reader. If stdout is not the terminal that will answer, the reply cannot be
+matched reliably.
+
+**Fix:** Keep the TUI on the terminal stream that will answer terminal queries. Keeping a TUI on
+stderr reserves stdout for CLI output, but it does not make cursor-position queries safe if the
+query implementation writes somewhere else.
+
+#### Terminal-querying libraries lose replies to EventStream
+
+**Symptom:** A terminal-querying library receives an incomplete ANSI sequence while the TUI is using
+[`EventStream`].
+
+**Cause:** [crossterm/crossterm#1039] reports a TUI using [`EventStream`] at the same time another
+library sends and receives ANSI sequences to display images. [`EventStream`] can consume part of the
+terminal reply before the other library sees it. [`stdin.lock()`][`Stdin::lock`] did not help
+because Crossterm uses its own internal event reader.
+
+**Fix:** Make the terminal owner run the query, or stop and recreate the event stream before another
+component owns the terminal bytes.
+
+#### Terminal color queries become normal input
+
+**Symptom:** Pasted or dragged input can be truncated or misclassified while terminal color probes
+are active. One Codex symptom was dragging screenshots into the CLI and getting half of the pasted
+path instead of an image attachment.
+
+**Cause:** Foreground/background color queries use OSC replies that arrive through the same terminal
+input path as keys, paste, and mouse events.
+
+**Fix:** The [Codex color-query patch] moved foreground/background color queries into the Crossterm
+event loop. The repair was not "try harder to parse in two places"; it was to put query replies and
+normal events through one terminal reader.
+
+### Handoffs leak terminal ownership
+
+#### Child TUI or shell handoff loses input
+
+**Symptom:** A child TUI, pager, shell command, or image protocol helper does not receive the input
+that the user types after the parent app appears to hand off the terminal.
+
+**Cause:** The parent event stream can keep reading stdin even when the app is not actively polling
+it. The [Codex EventStream refactor] introduced a broker so Codex could drop and recreate
+Crossterm's event stream around handoffs.
+
+**Fix:** Stop the parent reader before the child owns the terminal. Restore terminal modes, run the
+child, re-enter the TUI, flush or reconcile stale input, and only then recreate or resume the parent
+event reader.
+
+#### Suspend and resume inject terminal bytes
+
+**Symptom:** After `Ctrl+Z` / `fg`, the composer redraws in the wrong place or raw focus-report
+bytes appear in the prompt.
+
+**Cause:** The [Codex suspend fix] addressed a Linux suspend/resume failure where shell job-control
+output moved the cursor while the app was suspended, and terminal input polling could race with the
+replies used to restore the inline viewport.
+
+**Fix:** Pause input polling while suspended, flush buffered input before resuming it,
+re-synchronize raw mode, and probe the post-resume cursor position before drawing.
+
+### Rendering falls behind
+
+#### Resize redraw repeatedly stalls a large UI
+
+**Symptom:** The UI falls behind during resize and keeps rendering stale intermediate frames.
+
+**Cause:** The [Codex resize reflow guardrails] were added because large transcripts could keep
+doing expensive full rebuilds during terminal resize. This is not a protocol race; it is executor
+and UI starvation while the app keeps rebuilding and flushing frames that the user no longer needs.
+
+**Fix:** Measure render and terminal flush time, cap the rows processed, coalesce resize work, and
+disable the expensive reflow path for the session when it exceeds its budget.
+
+These mistakes surface as timeouts, missing paste bytes, raw escape sequences in the prompt, child
+processes that do not receive input, or a UI that falls behind during resize. Start debugging these
+by asking which code path owns terminal input, which path writes terminal queries, and whether
+drawing is keeping the event loop from catching up. If terminal ownership is correct but the
+symptoms still look like input lag or delayed redraws, look for CPU-heavy or blocking work running
+on the same executor threads as the UI.
+
+## Responsiveness patterns
+
+### Keep draw fast
+
+[`Terminal::draw`] is synchronous. Treat it as a render step, not a place to wait for work.
+Rendering a large diff or writing to a slow terminal can take longer than the 10-100 microsecond
+rule of thumb in [Async: What is blocking?]. That does not make [`Terminal::draw`] wrong; terminal
+rendering is the synchronous boundary of the application. It does mean the async task that calls
+[`Terminal::draw`] will not yield while Ratatui is building and writing that frame. On a
+current-thread runtime, that can delay every other task on the runtime. On a multi-thread runtime,
+it still occupies one worker thread for the duration of the draw.
+
+Debug builds can make this more visible. A Ratatui app running under `cargo run` may spend far more
+time per draw than the same app built with `cargo run --release`, and a debug draw can be close to
+or well above the 100 microsecond end of that rule of thumb. Use debug-mode responsiveness to expose
+slow paths while developing, but measure release builds before deciding where the production
+bottleneck is.
+
+Avoid these operations inside rendering code:
+
+- network requests
+- child process waits
+- sleeps
+- expensive parsing or layout preparation
+- locks that can be held by background tasks for a long time
+- extra terminal queries that read from stdin
+
+Prepare state before drawing, then render that state. Slow drawing directly increases input latency:
+the application cannot react to new terminal events while it is still building and writing the
+current frame. In an async application, it can also slow unrelated futures that are scheduled on the
+same runtime thread.
+
+Resize and mouse input make this visible. Resize events can arrive in bursts, and mouse hit testing
+often depends on the most recent layout. If drawing is expensive, consider draining pending terminal
+events before the next redraw, coalescing repeated resize events, or setting a dirty flag so the
+next frame uses the newest state instead of rendering each intermediate state.
+
+If draw time is consistently large, reduce the amount of work done per frame, cap the frame rate,
+and avoid drawing when nothing changed. Applications with strict async scheduling requirements can
+also put the terminal owner on a dedicated thread and communicate with the async runtime through
+channels. That does not make terminal I/O asynchronous, but it keeps slow terminal writes from
+monopolizing an async executor worker.
+
+Measure render work and terminal flush work separately when a path can become large. Expensive
+terminal resize or scrollback repair paths should have a budget and a fallback. The [Codex resize
+reflow guardrails] added timing, row caps, and a bounded failure mode so very large transcripts did
+not repeatedly stall the UI during resize.
+
+### Drain bursts before drawing
+
+Do not make every terminal event, process-output line, or worker message trigger its own draw. A
+paste, mouse drag, resize, or stream of child-process output can arrive faster than the terminal can
+render. If the loop handles one event and then draws, the queue keeps aging while each frame blocks
+the event loop. Keyboard input starts to feel laggy because the application is rendering obsolete
+intermediate states instead of catching up.
+
+Treat input as a reason to update state and mark the UI dirty. Before drawing, drain the currently
+available events and messages, coalesce repeated events, and render the newest state once:
+
+- keep the latest resize event instead of drawing every intermediate size
+- fold repeated progress updates into the latest progress value
+- debounce high-frequency text input before starting expensive searches or filters
+- batch child-process output and file-watcher changes by count or by a short timeout
+- process all queued key and mouse events that are already available, up to a small fairness budget
+- draw once after the drain pass if the state changed
+
+```rust title="drain then draw"
+{{ #include @code/concepts/async-applications/src/drain.rs:drain_then_draw }}
+```
+
+#### Bound the drain
+
+The fairness budget matters when producers are faster than the terminal. If events are still queued
+after the budget, draw the newest state, yield back to the runtime, and continue draining on the
+next turn. This prevents an unbounded drain loop while also avoiding the pattern where each stale
+event forces another synchronous terminal write.
+
+Yazi's [Yazi app loop] follows this shape in a production Ratatui application: it receives one
+event, drains the rest of the currently queued events with [`try_recv`], dispatches all of them, and
+then schedules rendering from a render flag. Yazi also distinguishes full and partial render
+requests with [render flags], so progress and notifications can request cheaper partial updates
+instead of forcing every update through a full redraw.
+
+#### Coalesce resize and command bursts
+
+Resize events need extra care because terminal emulators can report intermediate dimensions while
+the user drags the window, then settle on a final size after the repaint that handled the previous
+event. Track the latest observed size separately from the size that has actually been redrawn.
+Debounce resize-sensitive rebuilds, and schedule one follow-up draw if the final reported size may
+have arrived after the last rebuild. If a resize happens while streaming output is still represented
+by temporary UI state, record that fact and run one final source-backed repair after the stream is
+consolidated.
+
+The same rule applies inside event handlers. A paste, macro, or command sequence can expand into
+many application actions. If running the whole sequence would block input and rendering for a long
+time, run a bounded part of it and requeue the rest as application messages. That keeps the state
+machine ordered while still giving timers, input, and rendering a chance to run between chunks.
+
+#### Separate redraw requests from drawing
+
+For noisy background producers, separate "something changed" from "draw now." Language server
+messages, debugger events, status updates, diagnostics, and file watches can all request a redraw
+without forcing an immediate frame. The event loop can then turn many redraw requests into one
+scheduled redraw, for example at a fixed frame budget or after a short delay. Clear or drain stale
+redraw notifications when a frame starts so old notifications do not immediately schedule another
+identical frame.
+
+### Discard stale async results
+
+Async work can finish after the user has moved on. A completion request for an old input value, a
+search result for an old query, a preview for an old file, or a directory scan for an old location
+should not overwrite the current interface just because it finished later.
+
+Use one or more of these guards:
+
+- abort the previous task when a newer request supersedes it
+- attach a generation, ticket, or request id to each task and apply the result only if it still
+  matches current state
+- use a [`oneshot`][`tokio::sync::oneshot`] channel per request when each request has exactly one
+  reply, or a [`watch`][`tokio::sync::watch`] channel when only the latest value matters
+- treat a closed result channel as cancellation and make long-running blocking work check for it
+- make external streams report partial results with the generation that created them, then mark that
+  generation done when the stream ends
+
+```rust title="discard stale search results"
+{{ #include @code/concepts/async-applications/src/stale.rs:discard_stale }}
+```
+
+Check again before applying the result. Cancellation is cooperative, and some work cannot be
+canceled once it has been sent to another process, language server, filesystem watcher, or blocking
+thread. Capture the document id, view id, cursor position, query text, savepoint, or generation that
+made the request meaningful, then re-read current state on the UI side before mutating the
+interface.
+
+Staleness is separate from error handling. A stale success and a stale failure should both be
+ignored if they belong to a request that is no longer current. Report errors for the active request;
+drop or log errors for superseded work according to their diagnostic value.
+
+Real applications use this guard. Yazi's completion paths compare [completion tickets] before
+applying completion UI updates. Helix's [diff worker] debounces document changes and keeps the
+latest queued document or diff-base text, so intermediate states do not each force a diff or redraw.
+
+#### Select loops need cancellation-safe branches
+
+Tokio's [`tokio::select!`] docs use a stricter name for part of this rule: cancellation safety. In a
+loop, `select!` drops the futures for branches that did not win that iteration. That is safe only
+when dropping and recreating the future is a no-op for the operation's logical progress. Channel
+receives such as [`mpsc::Receiver::recv`] and stream [`next`][`StreamExt::next`] calls are designed
+for this; [`read_exact`], [`read_to_end`], [`write_all`], and queued [`Mutex::lock`] acquisition are
+not. If a TUI selects over worker results, shutdown, and terminal events, keep partial protocol
+reads and multi-step writes behind an owner that can finish, buffer, or abort them deliberately.
+
+## Coordination patterns
+
+Choose the background pattern by the shape of the data that must reach the UI owner.
+
+### Message passing
+
+Use message passing when background work produces discrete events:
+
+- HTTP request completed
+- process output line arrived
+- file watcher noticed a change
+- user submitted a form that starts work
+- background operation failed
+
+[`tokio::sync::mpsc`] works well for this shape. Use bounded channels when producers can outpace the
+UI and the application needs backpressure. Use unbounded channels only when the event rate is
+naturally small or the producer already has its own limit.
+
+Tokio's [channels tutorial] uses this pattern for a dedicated task that owns an I/O resource and
+receives commands from other tasks. It also points out that async Rust does not create implicit
+queues for you: queuing starts when the application introduces [`tokio::spawn`], [`tokio::select!`],
+[`tokio::join!`], or an mpsc channel. That is the same boundary a TUI often wants around terminal
+I/O, network clients, child processes, and long-running workers. Once the queue exists, choose its
+bound and its overload behavior deliberately.
+
+[`tokio::sync::watch`] fits data where the UI only needs the newest value and older values can be
+discarded: status text, progress snapshots, selected-task state, and other "latest value" streams.
+Use [`mpsc`][`tokio::sync::mpsc`] for discrete events that must be handled one by one; use
+[`watch`][`tokio::sync::watch`] when replacing an old value is the point.
+
+### Latest-value state
+
+Use shared state when the UI only needs the latest value:
+
+- a one-shot HTTP fetch
+- a cached list of pull requests
+- a status value updated by a task
+- a progress snapshot
+
+The [`async-github` example] uses [`Arc`][`std::sync::Arc`] and [`RwLock`][`std::sync::RwLock`] for
+this kind of shared state. The example is a small background fetcher, not a full event framework.
+Larger applications often combine shared state for cached data with channels for events and errors.
+
+Shared state should not become hidden event flow. If the UI must observe every transition, use a
+message. If the UI only needs to render the current snapshot, shared state or [`tokio::sync::watch`]
+can reduce queue churn. Avoid holding a contended lock while rendering; copy the state needed for
+the frame, release the lock, then draw.
+
+### Resource actors
+
+Use an actor when a long-lived resource needs one owner and a mailbox. In the Tokio and Alice Ryhl
+actor model, the actor owns the state or I/O resource, and handle structs send messages to it over
+channels. Requests that need a response usually include a [`oneshot`][`tokio::sync::oneshot`]
+sender. This maps well to TUI applications:
+
+- a terminal actor owns raw mode, event reading, drawing, resize handling, and terminal queries
+- a connection actor owns a websocket, database connection, or API client
+- a child-process actor owns stdin, stdout, stderr, restart, and cancellation for a long-running
+  command
+- a search or preview actor owns a cache and decides whether to cancel, replace, or ignore stale
+  requests
+
+Actors are a pattern, not a requirement that the actor itself be an async task. A terminal actor can
+be a dedicated blocking thread that receives messages from Tokio tasks. A network actor is usually a
+Tokio task. A CPU-heavy actor may use [`spawn_blocking`], [Rayon], or a normal thread pool
+internally. Ownership is the reason to use the pattern: other tasks ask the actor to do work instead
+of sharing the resource directly.
+
+Use bounded channels for actors that can fall behind. Backpressure is part of the design, not an
+afterthought. If an actor receives requests faster than it can process them, decide whether senders
+should wait, drop work, replace the queued request, cancel old work, or shut the actor down. Alice's
+[Actors with Tokio] article also calls out shutdown and cycles: bounded channel cycles can deadlock
+if every actor is waiting for another actor to receive.
+
+Tokio's [Graceful Shutdown] topic gives the same shape in runtime terms: decide when shutdown
+starts, tell every task or actor to shut down, then wait for them to finish. In a TUI, that plan
+also has to restore terminal modes, stop event readers, flush or drop queued terminal input, and
+decide what happens to blocking workers that cannot be cancelled immediately.
+
+### Blocking work
+
+Blocking work includes terminal writes and reads, synchronous filesystem or stdio operations,
+process waits, compression, large parses, diffing, search, syntax highlighting, and any CPU-heavy
+calculation that can run long enough to delay input or redraws. The rule is the same as for
+[`Terminal::draw`]: keep it out of the async UI task unless it is bounded and cheap.
+
+Use [`spawn_blocking`] or a dedicated thread for blocking work. Tokio's [`spawn_blocking`] runs a
+closure on a thread where blocking is acceptable, but that does not make CPU-heavy work unlimited.
+Tokio documents that the `spawn_blocking` upper thread limit is large because it is also used for
+I/O that has no async interface. For CPU-bound work, limit parallelism with a
+[`tokio::sync::Semaphore`], [Rayon], or another CPU-bound executor so background work does not take
+over the machine while the terminal is trying to stay responsive.
+
+Use [`spawn_blocking`] for bounded operations that eventually finish. Use dedicated threads for
+long-lived or persistent blocking workloads. [`block_in_place`] is rarely the right TUI boundary: it
+can let the multi-thread runtime hand other tasks to another worker, but it suspends other work
+inside the same async task, cannot be used on the current-thread runtime, and does not make the
+blocking work cancelable. Tokio's [`spawn_blocking`] docs also warn that a started blocking task
+cannot be aborted; runtime shutdown will wait for it unless the runtime uses a timeout, and that
+timeout still does not cancel the blocking task. Alice Ryhl's [Async: What is blocking?] explains
+the scheduling reason an async task should not spend a long time without reaching an `.await`.
+
+### Redraw scheduling
+
+A frame scheduler can be a small actor. It receives many "please draw" requests, clamps them to a
+frame budget, and emits one draw notification to the UI loop. Codex's [frame scheduler] follows this
+shape: background tasks request a frame, the scheduler coalesces those requests, and only the
+terminal owner performs the draw.
+
+Helix, which has its own terminal UI stack rather than Ratatui, uses the same separation. Async code
+can call [request_redraw], while the [Helix application loop] decides when to render. Its redraw
+module also has frame locks for work that should finish before the next frame. That is more
+application machinery than a small Ratatui app needs, but it is the same idea: background tasks
+request a frame; the terminal owner performs it.
+
+## Common mistakes
+
+### Awaiting work inside input handling
+
+Do not wait for application work inside the input branch if the interface should stay responsive.
+For example, when a key press or form submission starts a login request, spawn a task and set
+`app.login_state` to `Loading`. If the event loop awaits the HTTP request directly, it will stop
+handling resize events, keyboard input, and cancellation until the request finishes.
+
+```rust title="spawn work from an input event"
+match key.code {
+    KeyCode::Enter if app.login_state.can_start() => {
+        app.login_state = LoginState::Loading;
+        let request = app.login_request();
+        let ui_tx = ui_tx.clone();
+
+        tokio::spawn(async move {
+            let message = match login(request).await {
+                Ok(user) => UiMessage::LoginFinished(user),
+                Err(error) => UiMessage::LoginFailed(error.to_string()),
+            };
+
+            let _ = ui_tx.send(message).await;
+        });
+
+        app.dirty = true;
+    }
+    KeyCode::Esc => app.cancel_login(),
+    _ => {}
+}
+```
+
+### Recurring rule violations
+
+Three more mistakes show up constantly in review. Each violates a rule covered earlier, so they are
+listed here as a checklist rather than re-derived:
+
+- **Running CPU work on the UI task.** Do not run CPU-heavy work directly in a [`tokio::select!`]
+  branch, event handler, or render path. Start a worker, bound its concurrency, and send a result or
+  progress message back to the terminal owner. A fast path can stay inline; a path that scales with
+  file size, directory size, scrollback length, search corpus, image size, or diff size should have
+  an explicit budget. See [Blocking work](#blocking-work).
+- **Writing around the terminal owner.** Do not write logs or progress text directly to stdout while
+  the alternate screen is active. Send log events to the UI or use the logging recipe. If the
+  application needs to print final output for a shell pipeline, keep the TUI on stderr and reserve
+  stdout for the final value. See the FAQ entry on [stdout and stderr].
+- **Leaving the parent reader active.** Do not keep terminal event handling running while launching
+  another full-screen terminal program. Restore the terminal and hand control to the child process,
+  then re-enter the TUI after the child process exits. The [spawn Vim recipe] shows that lifecycle,
+  and [Handoffs leak terminal ownership](#handoffs-leak-terminal-ownership) shows the failure.
+
+## Studying real applications
+
+Older async tutorials and the real applications this page cites — Yazi, Codex, gitui, bottom, bacon,
+dua-cli, tokio-console, crates-tui, Helix, and Termina — are surveyed in
+[Async Application Examples](/concepts/application-patterns/async-application-examples/). That page
+audits the gaps in older templates and reads each application for the machinery this page describes:
+ownership boundaries, burst draining, coalescing, backpressure, cancellation, terminal handoffs, and
+redraw scheduling.
+
+The rules on this page are also a to-do list for the libraries. Each rule exists because a boundary
+is missing from the stack — ownership as a type, a query router, a render/present split, built-in
+frame scheduling. [Async Gaps and Direction](/concepts/application-patterns/async-gaps/) inventories
+those gaps and describes the work that would make the rules unnecessary.
+
+## Further reading
+
+Use the first group as direct support for API, protocol, and ownership claims. Use the second group
+to build background context before changing terminal lifecycle or async architecture.
+
+### Cite directly
+
+- **Tokio stdio and blocking work:** [`tokio::io::stdin`], [`tokio::io::Stdout`], and
+  [`spawn_blocking`].
+- **Crossterm ownership and terminal modes:** Crossterm's [event module] and [terminal module].
+- **Terminal protocol replies:** [Console Virtual Terminal Sequences] and [XTerm control sequences].
+- **CLI pipe and terminal boundaries:** [`std::io::IsTerminal`], the [Rust CLI book] chapter on
+  communicating with machines, and the [stdout and stderr] FAQ entry.
+
+### Read for background
+
+- **Async scheduling and ownership:** [Async: What is blocking?], [Actors with Tokio], [`select!`
+  tutorial], [channels tutorial], [Bridging with sync code], and [Graceful Shutdown].
+- **General Tokio I/O framing:** [Tokio I/O tutorial] and [Tokio Async in depth].
+- **TTY and raw-mode background:** [`termios(3)`], [A Brief Introduction to termios], [The TTY
+  demystified], and [Explore Linux TTY, process, signals with Rust].
+
+[A Brief Introduction to termios]:
+  https://blog.nelhage.com/2009/12/a-brief-introduction-to-termios-termios3-and-stty/
+[Actors with Tokio]: https://ryhl.io/blog/actors-with-tokio/
+[Async: What is blocking?]: https://ryhl.io/blog/async-what-is-blocking/
+[Bridging with sync code]: https://tokio.rs/tokio/topics/bridging
+[CPU-bound tasks and blocking code]:
+  https://docs.rs/tokio/latest/tokio/#cpu-bound-tasks-and-blocking-code
+[Codex EventStream refactor]:
+  https://github.com/openai/codex/commit/cf44511e7780bc30286ec356849970ff7aeabebb
+[Codex color-query patch]:
+  https://github.com/openai/codex/commit/07b8bdfbf1497cf7c478872bd082a13c5bd82c63
+[Codex resize reflow guardrails]:
+  https://github.com/openai/codex/commit/3aa637c4750715cf23589ee3f4b1d0b6563c7d3e
+[Codex suspend fix]: https://github.com/openai/codex/commit/76135cbe7ec8dbcc165aa1f2bd21358f9f1c6571
+[Console Virtual Terminal Sequences]:
+  https://learn.microsoft.com/en-us/windows/console/console-virtual-terminal-sequences
+[Explore Linux TTY, process, signals with Rust]:
+  https://developerlife.com/2024/08/20/tty-linux-async-rust/
+[Graceful Shutdown]: https://tokio.rs/tokio/topics/shutdown
+[Helix application loop]:
+  https://github.com/helix-editor/helix/blob/a2c9f44a564592257334ce0cec2fc904412173b5/helix-term/src/application.rs
+[Rayon]: https://docs.rs/rayon/latest/rayon/
+[Rust CLI book]: https://rust-cli.github.io/book/in-depth/machine-communication.html
+[Termina poll]:
+  https://github.com/helix-editor/termina/blob/4efcdc689e5abfe27e165a4840a1d612bc52758c/src/event/reader.rs#L116-L133
+[Termina read]:
+  https://github.com/helix-editor/termina/blob/4efcdc689e5abfe27e165a4840a1d612bc52758c/src/event/reader.rs#L138-L149
+[The TTY demystified]: https://www.linusakesson.net/programming/tty/
+[Tokio Async in depth]: https://tokio.rs/tokio/tutorial/async
+[Tokio I/O tutorial]: https://tokio.rs/tokio/tutorial/io
+[Tokio main macro source]:
+  https://github.com/tokio-rs/tokio/blob/c637f6e73d06f36d933cc3edaf45111c06b79c18/tokio-macros/src/lib.rs#L37-L42
+[Tokio multi-thread block_on source]:
+  https://github.com/tokio-rs/tokio/blob/c637f6e73d06f36d933cc3edaf45111c06b79c18/tokio/src/runtime/scheduler/multi_thread/mod.rs#L83-L87
+[XTerm control sequences]: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html
+[Yazi app loop]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-fm/src/app/app.rs#L34-L93
+[`Backend::append_lines`]:
+  https://docs.rs/ratatui/latest/ratatui/backend/trait.Backend.html#method.append_lines
+[`Backend::draw`]: https://docs.rs/ratatui/latest/ratatui/backend/trait.Backend.html#tymethod.draw
+[`Backend::flush`]: https://docs.rs/ratatui/latest/ratatui/backend/trait.Backend.html#tymethod.flush
+[`Backend::get_cursor_position`]:
+  https://docs.rs/ratatui/latest/ratatui/backend/trait.Backend.html#tymethod.get_cursor_position
+[`Backend::size`]: https://docs.rs/ratatui/latest/ratatui/backend/trait.Backend.html#tymethod.size
+[`Backend::window_size`]:
+  https://docs.rs/ratatui/latest/ratatui/backend/trait.Backend.html#tymethod.window_size
+[`CrosstermBackend::get_cursor_position` source]:
+  https://github.com/ratatui/ratatui/blob/d301c75f40854718374838ea3d6d704136b62e06/ratatui-crossterm/src/lib.rs#L302-L306
+[`CrosstermBackend::size` source]:
+  https://github.com/ratatui/ratatui/blob/d301c75f40854718374838ea3d6d704136b62e06/ratatui-crossterm/src/lib.rs#L337-L340
+[`EventStream`]: https://docs.rs/crossterm/latest/crossterm/event/struct.EventStream.html
+[`EventStream` source]:
+  https://github.com/crossterm-rs/crossterm/blob/3cea5b2d1d0c1cd4f285d18791b32e4b15e9bc0e/src/event/stream.rs#L42-L148
+[`Frame`]: https://docs.rs/ratatui/latest/ratatui/struct.Frame.html
+[`Interval`]: https://docs.rs/tokio/latest/tokio/time/struct.Interval.html
+[`MissedTickBehavior`]: https://docs.rs/tokio/latest/tokio/time/enum.MissedTickBehavior.html
+[`Mutex::lock`]: https://docs.rs/tokio/latest/tokio/sync/struct.Mutex.html#method.lock
+[`Runtime::block_on`]:
+  https://docs.rs/tokio/latest/tokio/runtime/struct.Runtime.html#method.block_on
+[`Stdin::lock`]: https://doc.rust-lang.org/std/io/struct.Stdin.html#method.lock
+[`StreamExt::next`]: https://docs.rs/futures/latest/futures/stream/trait.StreamExt.html#method.next
+[`Terminal::autoresize`]:
+  https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html#method.autoresize
+[`Terminal::clear`]: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html#method.clear
+[`Terminal::clear` source]:
+  https://github.com/ratatui/ratatui/blob/d301c75f40854718374838ea3d6d704136b62e06/ratatui-core/src/terminal/buffers.rs#L147-L151
+[`Terminal::draw`]: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html#method.draw
+[`Terminal::resize` source]:
+  https://github.com/ratatui/ratatui/blob/d301c75f40854718374838ea3d6d704136b62e06/ratatui-core/src/terminal/resize.rs#L23-L55
+[`Terminal::try_draw` source]:
+  https://github.com/ratatui/ratatui/blob/d301c75f40854718374838ea3d6d704136b62e06/ratatui-core/src/terminal/render.rs#L189-L205
+[`Terminal`]: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html
+[`Viewport::Inline`]: https://docs.rs/ratatui/latest/ratatui/enum.Viewport.html#variant.Inline
+[`async-github` example]:
+  https://github.com/ratatui/ratatui/tree/d301c75f40854718374838ea3d6d704136b62e06/examples/apps/async-github
+[`block_in_place`]: https://docs.rs/tokio/latest/tokio/task/fn.block_in_place.html
+[`compute_inline_size` source]:
+  https://github.com/ratatui/ratatui/blob/d301c75f40854718374838ea3d6d704136b62e06/ratatui-core/src/terminal/inline.rs#L390-L406
+[`crossterm Unix size source`]:
+  https://github.com/crossterm-rs/crossterm/blob/3cea5b2d1d0c1cd4f285d18791b32e4b15e9bc0e/src/terminal/sys/unix.rs#L61-L105
+[`crossterm cursor position source`]:
+  https://github.com/crossterm-rs/crossterm/blob/3cea5b2d1d0c1cd4f285d18791b32e4b15e9bc0e/src/cursor/sys/unix.rs#L20-L65
+[`crossterm internal event reader source`]:
+  https://github.com/crossterm-rs/crossterm/blob/3cea5b2d1d0c1cd4f285d18791b32e4b15e9bc0e/src/event/internal.rs#L9-L53
+[`crossterm::cursor::position()`]:
+  https://docs.rs/crossterm/latest/crossterm/cursor/fn.position.html
+[`crossterm::event::poll`]: https://docs.rs/crossterm/latest/crossterm/event/fn.poll.html
+[`crossterm::event::read`]: https://docs.rs/crossterm/latest/crossterm/event/fn.read.html
+[`crossterm::terminal::size()`]: https://docs.rs/crossterm/latest/crossterm/terminal/fn.size.html
+[`cursor::position()`]: https://docs.rs/crossterm/latest/crossterm/cursor/fn.position.html
+[`futures_core::Stream`]: https://docs.rs/futures-core/latest/futures_core/stream/trait.Stream.html
+[`mpsc::Receiver::recv`]:
+  https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.Receiver.html#method.recv
+[`println!`]: https://doc.rust-lang.org/std/macro.println.html
+[`read_exact`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read_exact
+[`read_to_end`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncReadExt.html#method.read_to_end
+[`select!` tutorial]: https://tokio.rs/tokio/tutorial/select
+[`spawn_blocking`]: https://docs.rs/tokio/latest/tokio/task/fn.spawn_blocking.html
+[`std::io::IsTerminal`]: https://doc.rust-lang.org/std/io/trait.IsTerminal.html
+[`std::sync::Arc`]: https://doc.rust-lang.org/std/sync/struct.Arc.html
+[`std::sync::RwLock`]: https://doc.rust-lang.org/std/sync/struct.RwLock.html
+[`supports_keyboard_enhancement()`]:
+  https://docs.rs/crossterm/latest/crossterm/terminal/fn.supports_keyboard_enhancement.html
+[`termios(3)`]: https://man7.org/linux/man-pages/man3/termios.3.html
+[`tokio::io::Stdout`]: https://docs.rs/tokio/latest/tokio/io/struct.Stdout.html
+[`tokio::io::stdin`]: https://docs.rs/tokio/latest/tokio/io/fn.stdin.html
+[`tokio::io::stdout()`]: https://docs.rs/tokio/latest/tokio/io/fn.stdout.html
+[`tokio::join!`]: https://docs.rs/tokio/latest/tokio/macro.join.html
+[`tokio::main`]: https://docs.rs/tokio/latest/tokio/attr.main.html
+[`tokio::select!`]: https://docs.rs/tokio/latest/tokio/macro.select.html
+[`tokio::spawn`]: https://docs.rs/tokio/latest/tokio/task/fn.spawn.html
+[`tokio::sync::Semaphore`]: https://docs.rs/tokio/latest/tokio/sync/struct.Semaphore.html
+[`tokio::sync::mpsc`]: https://docs.rs/tokio/latest/tokio/sync/mpsc/index.html
+[`tokio::sync::oneshot`]: https://docs.rs/tokio/latest/tokio/sync/oneshot/index.html
+[`tokio::sync::watch`]: https://docs.rs/tokio/latest/tokio/sync/watch/index.html
+[`try_recv`]:
+  https://docs.rs/tokio/latest/tokio/sync/mpsc/struct.UnboundedReceiver.html#method.try_recv
+[`write_all`]: https://docs.rs/tokio/latest/tokio/io/trait.AsyncWriteExt.html#method.write_all
+[bounded terminal probes]:
+  https://github.com/openai/codex/commit/127434cd8b968ca3d830ea78106dcb1506bcd843
+[channels tutorial]: https://tokio.rs/tokio/tutorial/channels
+[completion tickets]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-actor/src/input/complete.rs
+[crossterm/crossterm#1039]: https://github.com/crossterm-rs/crossterm/issues/1039
+[crossterm/crossterm#763]: https://github.com/crossterm-rs/crossterm/issues/763
+[crossterm/crossterm#919]: https://github.com/crossterm-rs/crossterm/issues/919
+[diff worker]:
+  https://github.com/helix-editor/helix/blob/a2c9f44a564592257334ce0cec2fc904412173b5/helix-vcs/src/diff/worker.rs
+[event module]: https://docs.rs/crossterm/latest/crossterm/event/index.html
+[filtered event reader]:
+  https://github.com/helix-editor/termina/blob/4efcdc689e5abfe27e165a4840a1d612bc52758c/src/event/reader.rs
+[frame scheduler]: https://github.com/openai/codex/commit/58e1e570faf0a2cb888acdb18df720f149b5006a
+[ratatui/ratatui#2483]: https://github.com/ratatui/ratatui/issues/2483
+[ratatui/ratatui#2485]: https://github.com/ratatui/ratatui/pull/2485
+[render flags]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-macro/src/render.rs
+[request_redraw]:
+  https://github.com/helix-editor/helix/blob/a2c9f44a564592257334ce0cec2fc904412173b5/helix-event/src/redraw.rs
+[spawn Vim recipe]: /recipes/apps/spawn-vim/
+[stdout and stderr]: /faq/#should-i-use-stdout-or-stderr
+[terminal module]: https://docs.rs/crossterm/latest/crossterm/terminal/index.html

--- a/src/content/docs/concepts/application-patterns/async-gaps.md
+++ b/src/content/docs/concepts/application-patterns/async-gaps.md
@@ -1,0 +1,209 @@
+---
+title: Async Gaps and Direction
+sidebar:
+  order: 6
+---
+
+[Async Applications](/concepts/application-patterns/async-applications/) documents the rules that
+async Ratatui applications follow today: pick one terminal owner, treat drawing as blocking I/O,
+treat query replies as input, drain bursts before drawing, serialize handoffs. Those rules work, but
+they live in documentation and application code instead of in library types. Each one is a
+workaround for a boundary that the libraries do not yet provide.
+
+This page inventories those gaps and describes the direction of work that would move each rule from
+convention into API. It is a statement of direction, not a schedule. Designs described here are in
+progress and subject to change. Where a status line refers to work-in-progress crate development,
+that work is currently private prototyping — read those lines as direction the authors are
+exploring, not as artifacts you can inspect or build against yet.
+
+## Where the rules come from
+
+| Rule you follow today         | Missing library boundary                                    |
+| ----------------------------- | ----------------------------------------------------------- |
+| Pick one terminal owner       | Ownership as a type that serializes terminal use            |
+| Treat query replies as input  | A protocol router that resolves replies and forwards events |
+| Treat drawing as blocking I/O | A render/present split with frames as values                |
+| Drain bursts, then draw once  | Frame scheduling in the library                             |
+| Serialize handoffs            | A session lifecycle: release, reacquire, suspend, resume    |
+| Cancel or tag stale work      | Application-level, with better primitives                   |
+
+When a boundary exists in the library, the corresponding rule stops being something an application
+can get wrong. The sections below take each gap in turn: what breaks today, what fixed looks like,
+and where the work stands.
+
+## Query replies race the input reader
+
+**Today.** Terminal queries write a request and receive the reply through the same input stream that
+carries keys, paste, mouse, and resize events. Whichever reader consumes the bytes first wins. This
+is the largest single class of failures in
+[Failure modes](/concepts/application-patterns/async-applications/#failure-modes): cursor-position
+timeouts ([ratatui/ratatui#2483]), replies lost to [`EventStream`] ([crossterm/crossterm#1039]),
+color-query replies misclassified as pasted input ([Codex color-query patch]), and queries that fail
+under redirection ([crossterm/crossterm#919]). The underlying design issue has been open in
+Crossterm since [crossterm/crossterm#763].
+
+**Fixed looks like.** One reader task owns the terminal input. Queries are futures: the reader
+matches replies against pending queries and resolves them; bytes that match no pending query flow
+through as ordinary events, in order. Late, malformed, and unmatched replies have defined behavior
+instead of racing. Redirected stdio fails fast instead of timing out. [`Termina`]'s [filtered event
+reader] shows one shape of this design: filters with buffered rejected events, inside the shared
+reader.
+
+**Status.** A private prototype is exploring this router design. Its tests cover reply matching,
+late and wrong-report replies, unmatched query-shaped input, and preserved unrelated input;
+redirected-terminal behavior is part of the design but not yet settled coverage.
+
+## Drawing fuses render, diff, and write
+
+**Today.** [`Terminal::draw`] is one fused operation: query the size, run the render closure, diff
+the buffers, write the changed cells, and flush ([`Terminal::try_draw` source]). The fusion is why
+the rules exist: the whole operation must happen under the terminal owner, it blocks whichever
+thread or task runs it, and with inline viewports it can also read terminal input mid-draw
+([`compute_inline_size` source]). Async wrappers cannot fix this from the outside; they can only
+schedule around it.
+
+**Fixed looks like.** Rendering and presenting are separate steps. Render turns application state
+into a [`Buffer`] — a pure, `Send` value that can be produced on any thread, with the size supplied
+as an input from resize events rather than queried mid-draw. Present diffs the newest buffer against
+the screen and writes, under the owner. Frames-as-values makes the hard patterns from the
+[coordination patterns](/concepts/application-patterns/async-applications/#coordination-patterns)
+section nearly free: latest-value presentation is a watch channel of buffers, coalescing is "present
+the newest," and render work stops competing with the executor. Inline viewports would route their
+cursor query through the same query router as everything else.
+
+That paragraph glosses over real design questions — autoresize semantics, cursor positioning, and
+backend compatibility among them. This split needs a design discussion in ratatui-core, not a patch.
+
+**Status.** Under design. A known escape hatch — a backend that captures draw bytes and flushes them
+asynchronously — has been prototyped and informs the design, but it inherits the fused semantics
+rather than fixing them.
+
+## Every application rebuilds frame scheduling
+
+**Today.** Nothing in the stack coalesces redraws, so every substantial application builds it: Codex
+has a [frame scheduler], Yazi has [render flags], Helix debounces [request_redraw]. Smaller
+applications copy the dirty-flag-and-budget pattern from
+[Drain bursts before drawing](/concepts/application-patterns/async-applications/#drain-bursts-before-drawing)
+— or do not, and redraw once per event until input lags.
+
+**Fixed looks like.** A redraw handle in the library layer: background work requests a frame,
+requests coalesce under a frame budget, and the owner presents once. If the render/present split
+lands, most of this machinery dissolves — "present the newest buffer at the frame budget" is a small
+amount of code, not a subsystem.
+
+**Status.** Blocked on the render/present design above, deliberately: building the scheduler first
+would bake the fused-draw shape in.
+
+## Handoffs and suspend/resume are hand-rolled
+
+**Today.** Handing the terminal to a child process, or surviving `Ctrl+Z` / `fg`, takes a precise
+sequence — pause the reader, restore modes, run the child, re-enter modes, flush stale input, resume
+— and the library provides none of it as an operation. Codex rebuilt its event stream around a
+broker to make the reader stoppable ([Codex EventStream refactor]) and fixed suspend/resume byte
+injection by hand ([Codex suspend fix]); gitui suspends its input thread around external editors
+([gitui input thread]).
+
+**Fixed looks like.** Release and reacquire as first-class session operations: release stops the
+reader, restores modes, and returns the terminal; reacquire re-enters modes, re-negotiates features
+(keyboard enhancement, bracketed paste, mouse), flushes stale input, and resumes events. Suspend and
+resume hook the same path via signal handling. Panic and drop run the same cleanup.
+
+**Status.** Planned next in the same private prototype work, behind query routing.
+
+## Async event sources are thread shims
+
+**Today.** [`EventStream`] is a helper thread parked on Crossterm's shared blocking reader, and
+[`tokio::io::stdin`] is a blocking read on a worker thread that cannot be cancelled. Neither is
+async terminal I/O; both are wake-up wrappers around blocking reads, which is why they cannot be
+paused, handed off, or composed with queries safely.
+
+**Fixed looks like.** On Unix, the terminal device itself is async: a nonblocking file descriptor
+registered with the runtime's readiness system, which makes reads genuinely cancellable. Windows
+needs a different shape, because the console APIs do not offer the same readiness model: an
+async-shaped API there means worker-backed handles for the current console, with ConPTY for host
+applications that run child processes — better-scoped workers than today's shims, not the same
+mechanism as Unix.
+
+**Status.** A private prototype has the Unix readiness model working; the Windows worker-backed
+design is sketched but not validated.
+
+## Failures are documented, not tested
+
+**Today.** The [failure modes](/concepts/application-patterns/async-applications/#failure-modes)
+catalog is war stories: each entry cites the commit or issue where a real application hit it and
+worked around it. Nothing prevents the next application from rediscovering each failure, because the
+failures live in prose rather than in any library's test suite.
+
+**Fixed looks like.** The catalog becomes a conformance suite. Every documented failure — the
+cursor-position race, the lost color reply, the redirected query, the suspend byte injection, the
+handoff that eats input — is an executable test against the terminal layer, and stays green as the
+libraries evolve. A fixture corpus of real terminal behavior (exact bytes, per-terminal quirks,
+support tiers) backs the tests so they do not just encode one emulator's behavior.
+
+**Status.** Prototype tests cover the query-routing portion; the handoff and suspend portions are
+planned alongside those features.
+
+## The path to green
+
+The workstreams above are ordered by dependency, not difficulty:
+
+1. **Design the render/present split in ratatui-core.** This is the only gap that needs changes in
+   Ratatui itself, and its outcome shapes everything downstream — watch for a design discussion on
+   the [Ratatui repository]. Independent of any async work, frames-as-values also improves testing
+   and non-terminal backends.
+2. **Finish the protocol foundation.** Query routing, session lifecycle, handoff, suspend/resume —
+   each landing with its conformance tests derived from the failure catalog.
+3. **Build the thin integration layer.** With frames as values and a routed session, the "terminal
+   actor" most large applications hand-roll reduces to a small library: a handle that renders
+   anywhere, presents under the owner, and schedules frames on a budget.
+4. **Port a real application.** A reference port of a nontrivial async app (for example
+   [`crates-tui`]) validates the design: every weakness in its
+   [audit](/concepts/application-patterns/async-application-examples/#ratatui-applications-with-more-machinery)
+   should either dissolve into the new API or be a conscious application decision.
+5. **Flip the documentation.** When the boundaries exist, the
+   [Async Applications](/concepts/application-patterns/async-applications/) page becomes the
+   explanation of how the machinery works, and a much shorter tutorial becomes the front door. The
+   failure catalog becomes links into the conformance suite that proves each failure stays fixed.
+
+None of this deprecates the current rules. Applications built on today's patterns — one owner,
+bounded channels, drained bursts — remain correct; the goal is that future applications get the same
+correctness from types instead of discipline.
+
+## Following along
+
+Design discussions will appear on the [Ratatui repository] and the [Ratatui Discord] as the pieces
+above take shape. The failure catalog on the
+[Async Applications](/concepts/application-patterns/async-applications/) page is the best statement
+of requirements; if you have hit an async terminal failure that it does not describe, an issue with
+the details is a direct contribution to the conformance suite.
+
+[`Buffer`]: https://docs.rs/ratatui/latest/ratatui/buffer/struct.Buffer.html
+[`EventStream`]: https://docs.rs/crossterm/latest/crossterm/event/struct.EventStream.html
+[`Terminal::draw`]: https://docs.rs/ratatui/latest/ratatui/struct.Terminal.html#method.draw
+[`Terminal::try_draw` source]:
+  https://github.com/ratatui/ratatui/blob/d301c75f40854718374838ea3d6d704136b62e06/ratatui-core/src/terminal/render.rs#L189-L205
+[`compute_inline_size` source]:
+  https://github.com/ratatui/ratatui/blob/d301c75f40854718374838ea3d6d704136b62e06/ratatui-core/src/terminal/inline.rs#L390-L406
+[`crates-tui`]: https://github.com/ratatui/crates-tui
+[`Termina`]: https://github.com/helix-editor/termina
+[`tokio::io::stdin`]: https://docs.rs/tokio/latest/tokio/io/fn.stdin.html
+[Codex EventStream refactor]:
+  https://github.com/openai/codex/commit/cf44511e7780bc30286ec356849970ff7aeabebb
+[Codex color-query patch]:
+  https://github.com/openai/codex/commit/07b8bdfbf1497cf7c478872bd082a13c5bd82c63
+[Codex suspend fix]: https://github.com/openai/codex/commit/76135cbe7ec8dbcc165aa1f2bd21358f9f1c6571
+[Ratatui Discord]: https://discord.gg/pMCEU9hNEj
+[Ratatui repository]: https://github.com/ratatui/ratatui
+[crossterm/crossterm#1039]: https://github.com/crossterm-rs/crossterm/issues/1039
+[crossterm/crossterm#763]: https://github.com/crossterm-rs/crossterm/issues/763
+[crossterm/crossterm#919]: https://github.com/crossterm-rs/crossterm/issues/919
+[filtered event reader]:
+  https://github.com/helix-editor/termina/blob/4efcdc689e5abfe27e165a4840a1d612bc52758c/src/event/reader.rs
+[frame scheduler]: https://github.com/openai/codex/commit/58e1e570faf0a2cb888acdb18df720f149b5006a
+[gitui input thread]:
+  https://github.com/extrawurst/gitui/blob/ee1bcd1eb344ba69bbc301f5b71db8030470e18b/src/input.rs#L40-L145
+[ratatui/ratatui#2483]: https://github.com/ratatui/ratatui/issues/2483
+[render flags]:
+  https://github.com/sxyazi/yazi/blob/6e0aaee8229afadfbcdc05fb6607b023da928b18/yazi-macro/src/render.rs
+[request_redraw]:
+  https://github.com/helix-editor/helix/blob/a2c9f44a564592257334ce0cec2fc904412173b5/helix-event/src/redraw.rs

--- a/src/content/docs/concepts/application-patterns/index.md
+++ b/src/content/docs/concepts/application-patterns/index.md
@@ -10,3 +10,6 @@ the following articles where these patterns are explored more in-depth.
 - [The Elm Architecture](./the-elm-architecture/)
 - [Component Architecture](./component-architecture/)
 - [Flux Architecture](./flux-architecture/)
+- [Async Applications](./async-applications/)
+- [Async Application Examples](./async-application-examples/)
+- [Async Gaps and Direction](./async-gaps/)

--- a/src/content/docs/concepts/widgets.md
+++ b/src/content/docs/concepts/widgets.md
@@ -187,8 +187,8 @@ Choose the implementation form based on ownership and state:
 - use `impl Widget for &MyWidget` for reusable widgets that do not mutate themselves during render
 - use `impl Widget for MyWidget` for cheap ephemeral widgets created fresh each frame
 - use `impl Widget for &mut MyWidget` when rendering updates state owned by the widget
-- use [`StatefulWidget`] when state should live outside the widget and persist independently, such as
-  selection, scroll offset, or cursor position
+- use [`StatefulWidget`] when state should live outside the widget and persist independently, such
+  as selection, scroll offset, or cursor position
 
 A useful state question is: if this widget value is recreated, should its state reset? If yes,
 widget-owned state can be fine. If no, keep the state outside the widget and pass it in.

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -303,30 +303,60 @@ main .content-panel:first-child:not(:has(*)) {
 
 @keyframes rat-run {
   0%,
-  100% { transform: translateX(-80px) scaleX(-1); }
-  48%  { transform: translateX(80px)  scaleX(-1); }
-  50%  { transform: translateX(80px)  scaleX(1); }
-  98%  { transform: translateX(-80px) scaleX(1); }
+  100% {
+    transform: translateX(-80px) scaleX(-1);
+  }
+  48% {
+    transform: translateX(80px) scaleX(-1);
+  }
+  50% {
+    transform: translateX(80px) scaleX(1);
+  }
+  98% {
+    transform: translateX(-80px) scaleX(1);
+  }
 }
 
 @keyframes rat-wiggle {
   0%,
-  100% { transform: rotate(0)     translateY(0); }
-  25%  { transform: rotate(-8deg) translateY(-2px); }
-  75%  { transform: rotate(8deg)  translateY(2px); }
+  100% {
+    transform: rotate(0) translateY(0);
+  }
+  25% {
+    transform: rotate(-8deg) translateY(-2px);
+  }
+  75% {
+    transform: rotate(8deg) translateY(2px);
+  }
 }
 
 @keyframes rat-shake {
   0%,
-  100% { transform: translateY(0); }
-  25%  { transform: translateY(-2px); }
-  50%  { transform: translateY(2px); }
-  75%  { transform: translateY(-1px); }
+  100% {
+    transform: translateY(0);
+  }
+  25% {
+    transform: translateY(-2px);
+  }
+  50% {
+    transform: translateY(2px);
+  }
+  75% {
+    transform: translateY(-1px);
+  }
 }
 
 @keyframes rat-jump {
-  0%   { transform: translateY(0)     rotate(0)      scale(1); }
-  30%  { transform: translateY(-28px) rotate(180deg) scale(1.15); }
-  70%  { transform: translateY(-6px)  rotate(360deg) scale(0.95); }
-  100% { transform: translateY(0)     rotate(360deg) scale(1); }
+  0% {
+    transform: translateY(0) rotate(0) scale(1);
+  }
+  30% {
+    transform: translateY(-28px) rotate(180deg) scale(1.15);
+  }
+  70% {
+    transform: translateY(-6px) rotate(360deg) scale(0.95);
+  }
+  100% {
+    transform: translateY(0) rotate(360deg) scale(1);
+  }
 }


### PR DESCRIPTION
## Summary

- add a comprehensive Async Applications concept page covering terminal ownership, blocking draw behavior, event draining, coordination patterns, and failure modes
- split the real-application survey and future async gaps/direction into companion pages
- move the main code samples into `code/concepts/async-applications/` so the docs examples are compile-tested
- include `code/concepts/*` in the Cargo workspace and update the Elm concept example metadata/formatting so workspace checks cover concept code

## Validation

- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo clippy --workspace -- -D warnings`
- `pnpm exec markdownlint-cli2 src/content/docs/concepts/application-patterns/async-applications.md src/content/docs/concepts/application-patterns/async-application-examples.md src/content/docs/concepts/application-patterns/async-gaps.md src/content/docs/concepts/application-patterns/index.md`
- `pnpm exec astro check`
- `pnpm exec astro build`
