### PR TITLE
fix(docs): correct three broken links on the showcase submission page

### DIFF
--- a/src/content/docs/recipes/apps/submitting-to-the-showcase.md
+++ b/src/content/docs/recipes/apps/submitting-to-the-showcase.md
@@ -153,9 +153,9 @@ iterating on the presentation first.
 
 ## Related reading
 
-- [Releasing Your App](./release-your-app/)
-- [App Showcase](../../showcase/apps/)
-- [Third Party Widgets](../../showcase/third-party-widgets/)
+- [Releasing Your App](/recipes/apps/release-your-app/)
+- [App Showcase](/showcase/apps/)
+- [Third Party Widgets](/showcase/third-party-widgets/)
 - [Issue #986: Ratatui app showcase criteria](https://github.com/ratatui/ratatui-website/issues/986)
 - [Issue #905: Improve Showcase Apps](https://github.com/ratatui/ratatui-website/issues/905)
 - [PR #1032 discussion](https://github.com/ratatui/ratatui-website/pull/1032)


### PR DESCRIPTION
The 'Related reading' section on https://ratatui.rs/recipes/apps/submitting-to-the-showcase/ used relative links that 404 from this leaf page:
- ./release-your-app/           -> /recipes/apps/submitting-to-the-showcase/release-your-app/ (404)
- ../../showcase/apps/          -> /recipes/showcase/apps/ (404)
- ../../showcase/third-party-widgets/ -> /recipes/showcase/third-party-widgets/ (404)

Changed all three to root-anchored links per CONTRIBUTING's link style.
