### PR TITLE
Add Nintendo Switch example to mousefood

### DIFF
--- a/src/content/docs/ecosystem/mousefood.md
+++ b/src/content/docs/ecosystem/mousefood.md
@@ -37,4 +37,9 @@ For example:
 [Ratatui running on PSP](https://github.com/overdrivenpotato/rust-psp/tree/master/examples/ratatui)
 via `rust-psp`
 
+![ratatui-on-nintendo-switch](https://media.githubusercontent.com/media/sermuns/ratatui-on-nintendo-switch/main/media/ratatui-and-mousefood-logos.jpg)
+
+[Ratatui running on Nintendo Switch](https://github.com/sermuns/ratatui-on-nintendo-switch)
+via [`nx`](https://github.com/aarch64-switch-rs/nx)
+
 :::


### PR DESCRIPTION
Adds my [`ratatui-on-ninteno-switch`](https://github.com/sermuns/ratatui-on-nintendo-switch) below PSP example of `mousefood`.

<img width="835" height="948" alt="image" src="https://github.com/user-attachments/assets/f344e483-73db-4a75-94d2-9a14765bbb69" />
