### PR TITLE
fix(landing): white logo variants for dark mode

### DIFF
--- a/src/assets/companies/Netflix_Logo_monochrome_white.png
+++ b/src/assets/companies/Netflix_Logo_monochrome_white.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6e092d4cb994c9dccb8bb564caf8462db2b8014360cb0523402d0a532236f86c
+size 13842

--- a/src/assets/companies/ovhcloud-logo-black.png
+++ b/src/assets/companies/ovhcloud-logo-black.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74136d66f7688f23a6ce0ccbdfd1054ea564698887298ebf6a15781d798e4d33
+size 42368

--- a/src/assets/companies/ovhcloud-logo-monochrome.png
+++ b/src/assets/companies/ovhcloud-logo-monochrome.png
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:73721edb5ad88e9863bc01f29bd401d96abfefe9cd8d8ff0efcd675c569a0fce
-size 73126

--- a/src/assets/companies/ovhcloud-logo-white.png
+++ b/src/assets/companies/ovhcloud-logo-white.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:81f8c8b0bd9082b68617a42243b19173119b613bddbd3fcf27f2a3daa6e34efa
+size 43809

--- a/src/components/CompanyLogos.astro
+++ b/src/components/CompanyLogos.astro
@@ -1,8 +1,10 @@
 ---
 import netflix from "@assets/companies/Netflix_Logo_monochrome.png";
+import netflix_white from "@assets/companies/Netflix_Logo_monochrome_white.png";
 import openai_white from "@assets/companies/OpenAI-white-wordmark.svg";
 import openai_black from "@assets/companies/OpenAI-black-wordmark.svg";
-import ovhcloud from "@assets/companies/ovhcloud-logo-monochrome.png";
+import ovhcloud_white from "@assets/companies/ovhcloud-logo-white.png";
+import ovhcloud_black from "@assets/companies/ovhcloud-logo-black.png";
 import aws_white from "@assets/companies/aws-logo-white.png";
 import aws_black from "@assets/companies/aws-logo-black.png";
 import oxide_white from "@assets/companies/OXIDE_Wordmark_RGB_White.svg";
@@ -18,7 +20,7 @@ import electronic_arts_white from "@assets/companies/ea-wordmark-white.svg";
 
 const logos = [
   {
-    darkMode: netflix,
+    darkMode: netflix_white,
     lightMode: netflix,
     href: "https://github.com/Netflix/bpftop",
     aria: "Netflix",
@@ -32,8 +34,8 @@ const logos = [
     class: "h-[55px] max-xl:h-[40px] max-sm:h-[30px] ml-[-8px]",
   },
   {
-    darkMode: ovhcloud,
-    lightMode: ovhcloud,
+    darkMode: ovhcloud_white,
+    lightMode: ovhcloud_black,
     href: "https://github.com/ovh/shai",
     aria: "OVH Cloud",
     class: "h-[35px] max-xl:h-[30px] max-sm:h-[20px]",


### PR DESCRIPTION
Netflix rendered gray in dark mode, and OVHcloud had a baked-in gray background box. Added a white Netflix variant and transparent white/black OVHcloud variants.

| | before | after |
|---|---|---|
| Netflix (dark) | gray | white |
| OVHcloud | white on gray box | transparent |

🤖 Generated with [Claude Code](https://claude.com/claude-code)