### PR TITLE
chore(deps): update sharp from 0.35.0 to 0.35.3

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,10 +21,10 @@ importers:
         version: 2.1.7
       "@astrojs/starlight":
         specifier: ^0.41.4
-        version: 0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)
+        version: 0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)
       "@astrojs/starlight-tailwind":
         specifier: ^5.0.0
-        version: 5.0.0(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))(tailwindcss@4.2.4)
+        version: 5.0.0(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))(tailwindcss@4.2.4)
       "@expressive-code/plugin-collapsible-sections":
         specifier: ^0.44.1
         version: 0.44.1
@@ -33,7 +33,7 @@ importers:
         version: 4.2.4(vite@8.1.5(@types/node@24.12.2)(esbuild@0.28.1)(jiti@2.6.1)(yaml@2.8.3))
       astro:
         specifier: ^7.1.3
-        version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
+        version: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
       hast-util-select:
         specifier: ^6.0.3
         version: 6.0.4
@@ -57,16 +57,16 @@ importers:
         version: 2.0.0
       sharp:
         specifier: ^0.35.0
-        version: 0.35.0
+        version: 0.35.3(@types/node@24.12.2)
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
       starlight-auto-sidebar:
         specifier: ^0.4.0
-        version: 0.4.0(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))
+        version: 0.4.0(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))
       starlight-links-validator:
         specifier: 0.25.2
-        version: 0.25.2(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))
+        version: 0.25.2(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -575,10 +575,10 @@ packages:
         integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
       }
 
-  "@emnapi/runtime@1.11.2":
+  "@emnapi/runtime@1.11.3":
     resolution:
       {
-        integrity: sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==,
+        integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==,
       }
 
   "@emnapi/wasi-threads@1.2.2":
@@ -877,237 +877,237 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@img/sharp-darwin-arm64@0.35.0":
+  "@img/sharp-darwin-arm64@0.35.3":
     resolution:
       {
-        integrity: sha512-ZgaYEwaj+lx/5n4W8GmZ2IYz0PQHjN5eqRcfijWGB+2Aq7ZInZGa0qJyAn6DEtyLuWHRSrmWOqT9q3qqTBvmUQ==,
+        integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [darwin]
 
-  "@img/sharp-darwin-x64@0.35.0":
+  "@img/sharp-darwin-x64@0.35.3":
     resolution:
       {
-        integrity: sha512-c1z9LFpKB0slQW3RchwBE8iSVzGp70TNjUUO9k4BZwwW4HH7JBGHeIy4b+kk4n/kcBASb9evKCE3/7Slmslgiw==,
+        integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [darwin]
 
-  "@img/sharp-freebsd-wasm32@0.35.0":
+  "@img/sharp-freebsd-wasm32@0.35.3":
     resolution:
       {
-        integrity: sha512-Li2KTev0H90kEtnJHkI9xQojXt1AqWmFBMXiPw5kqd1jQgP7gi5HVK/qC5Rmh/59NuAwUuPzzPITmX22NomYYQ==,
+        integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==,
       }
     engines: { node: ">=20.9.0" }
     os: [freebsd]
 
-  "@img/sharp-libvips-darwin-arm64@1.3.0":
+  "@img/sharp-libvips-darwin-arm64@1.3.2":
     resolution:
       {
-        integrity: sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==,
+        integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==,
       }
     cpu: [arm64]
     os: [darwin]
 
-  "@img/sharp-libvips-darwin-x64@1.3.0":
+  "@img/sharp-libvips-darwin-x64@1.3.2":
     resolution:
       {
-        integrity: sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==,
+        integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==,
       }
     cpu: [x64]
     os: [darwin]
 
-  "@img/sharp-libvips-linux-arm64@1.3.0":
+  "@img/sharp-libvips-linux-arm64@1.3.2":
     resolution:
       {
-        integrity: sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==,
+        integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==,
       }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-arm@1.3.0":
+  "@img/sharp-libvips-linux-arm@1.3.2":
     resolution:
       {
-        integrity: sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==,
+        integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==,
       }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-ppc64@1.3.0":
+  "@img/sharp-libvips-linux-ppc64@1.3.2":
     resolution:
       {
-        integrity: sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==,
+        integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==,
       }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-riscv64@1.3.0":
+  "@img/sharp-libvips-linux-riscv64@1.3.2":
     resolution:
       {
-        integrity: sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==,
+        integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==,
       }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-s390x@1.3.0":
+  "@img/sharp-libvips-linux-s390x@1.3.2":
     resolution:
       {
-        integrity: sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==,
+        integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==,
       }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linux-x64@1.3.0":
+  "@img/sharp-libvips-linux-x64@1.3.2":
     resolution:
       {
-        integrity: sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==,
+        integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==,
       }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-libvips-linuxmusl-arm64@1.3.0":
+  "@img/sharp-libvips-linuxmusl-arm64@1.3.2":
     resolution:
       {
-        integrity: sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==,
+        integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==,
       }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-libvips-linuxmusl-x64@1.3.0":
+  "@img/sharp-libvips-linuxmusl-x64@1.3.2":
     resolution:
       {
-        integrity: sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==,
+        integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==,
       }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-linux-arm64@0.35.0":
+  "@img/sharp-linux-arm64@0.35.3":
     resolution:
       {
-        integrity: sha512-4+4XHLNT5wDT0roYlHTEmH9lDKt0acf9Tv+3hM3iceOirkxrR404/3WjAYZ9F9CkHrxeRcGLJXbi4vluMZ9O+A==,
+        integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-arm@0.35.0":
+  "@img/sharp-linux-arm@0.35.3":
     resolution:
       {
-        integrity: sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==,
+        integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-ppc64@0.35.0":
+  "@img/sharp-linux-ppc64@0.35.3":
     resolution:
       {
-        integrity: sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==,
+        integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-riscv64@0.35.0":
+  "@img/sharp-linux-riscv64@0.35.3":
     resolution:
       {
-        integrity: sha512-l6vmKVPnbS0RhVMbyxP5meAARsbhCnBN4fy31qz0+3a6Rv4jEqfzDrT89y6ZPkCi0AJGnwp2En528yXo401Hpw==,
+        integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-s390x@0.35.0":
+  "@img/sharp-linux-s390x@0.35.3":
     resolution:
       {
-        integrity: sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==,
+        integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linux-x64@0.35.0":
+  "@img/sharp-linux-x64@0.35.3":
     resolution:
       {
-        integrity: sha512-TYaItB5oj1ioXjhyn2xrR208vf+YuIIcHptQWRRaBmFhvIvL9D72DXN8w75xup0KXA8UdEAhQ9Qb2S49FD/9Cw==,
+        integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@img/sharp-linuxmusl-arm64@0.35.0":
+  "@img/sharp-linuxmusl-arm64@0.35.3":
     resolution:
       {
-        integrity: sha512-DSTb6ijQzqe6DdAaOBVqJ/SYf1vO8EW5bK6X6LRXufEBebf2722VCdvBUtZ3rtV0x2ApfPNDy/p7LrrjaWjiyQ==,
+        integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-linuxmusl-x64@0.35.0":
+  "@img/sharp-linuxmusl-x64@0.35.3":
     resolution:
       {
-        integrity: sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==,
+        integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@img/sharp-wasm32@0.35.0":
+  "@img/sharp-wasm32@0.35.3":
     resolution:
       {
-        integrity: sha512-9woLIFORERCr+6cWu87dQ22J34EExkhc73U1kZW0c+RclQqWetoodByp4dWZ/hN8/KVmTRAx2HOnUwib8AwZdA==,
+        integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==,
       }
     engines: { node: ">=20.9.0" }
 
-  "@img/sharp-webcontainers-wasm32@0.35.0":
+  "@img/sharp-webcontainers-wasm32@0.35.3":
     resolution:
       {
-        integrity: sha512-t+kie1TOyaDM6Dho+f+y0VqIUNhYQaKCUahuZVi0E0frgdiaOaPsDxDW3wfKacUdaNBCnK/ZDBMg33ydvHj8uA==,
+        integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [wasm32]
 
-  "@img/sharp-win32-arm64@0.35.0":
+  "@img/sharp-win32-arm64@0.35.3":
     resolution:
       {
-        integrity: sha512-M5eKxug0dabbaWgFKvPa3odNs2OpaP+81NASfGKkt4GcYXpNhSu7CaeYxWkLNV6vHmUp4hnCxnxrUyhUJhXbKA==,
+        integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [arm64]
     os: [win32]
 
-  "@img/sharp-win32-ia32@0.35.0":
+  "@img/sharp-win32-ia32@0.35.3":
     resolution:
       {
-        integrity: sha512-z0+pZ03QCDvdVN0Ez9IX/yjWC19ikMlXrmdYMwYNLTh2BLPx3hXWPvyqWfquZ0BTO9O6GVOjIVoTcyyacMnWlQ==,
+        integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==,
       }
     engines: { node: ^20.9.0 }
     cpu: [ia32]
     os: [win32]
 
-  "@img/sharp-win32-x64@0.35.0":
+  "@img/sharp-win32-x64@0.35.3":
     resolution:
       {
-        integrity: sha512-feNnlz5ZHKr0MY1LPHvZQyJeBkbo4ctsn0D8FvA53VTw5TC63rfEL2UrWbkSBR19htSE7Mw78xYVwdJqoMWVHw==,
+        integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==,
       }
     engines: { node: ">=20.9.0" }
     cpu: [x64]
@@ -5287,12 +5287,17 @@ packages:
     engines: { node: ">=10" }
     hasBin: true
 
-  sharp@0.35.0:
+  sharp@0.35.3:
     resolution:
       {
-        integrity: sha512-BqvG5XbwPZ4NV0DK90d86leEECMsoa8bO0nqnKWlBDYxri4GJ7c4EDInaF6q20lTh/mATmnDIKWJFfXnoVfH5g==,
+        integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==,
       }
     engines: { node: ">=20.9.0" }
+    peerDependencies:
+      "@types/node": "*"
+    peerDependenciesMeta:
+      "@types/node":
+        optional: true
 
   shiki@4.0.2:
     resolution:
@@ -6294,9 +6299,9 @@ snapshots:
   "@astrojs/compiler-binding-linux-x64-musl@0.3.1":
     optional: true
 
-  "@astrojs/compiler-binding-wasm32-wasi@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)":
+  "@astrojs/compiler-binding-wasm32-wasi@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)":
     dependencies:
-      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
@@ -6308,7 +6313,7 @@ snapshots:
   "@astrojs/compiler-binding-win32-x64-msvc@0.3.1":
     optional: true
 
-  "@astrojs/compiler-binding@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)":
+  "@astrojs/compiler-binding@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)":
     optionalDependencies:
       "@astrojs/compiler-binding-darwin-arm64": 0.3.1
       "@astrojs/compiler-binding-darwin-x64": 0.3.1
@@ -6316,16 +6321,16 @@ snapshots:
       "@astrojs/compiler-binding-linux-arm64-musl": 0.3.1
       "@astrojs/compiler-binding-linux-x64-gnu": 0.3.1
       "@astrojs/compiler-binding-linux-x64-musl": 0.3.1
-      "@astrojs/compiler-binding-wasm32-wasi": 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      "@astrojs/compiler-binding-wasm32-wasi": 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
       "@astrojs/compiler-binding-win32-arm64-msvc": 0.3.1
       "@astrojs/compiler-binding-win32-x64-msvc": 0.3.1
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
 
-  "@astrojs/compiler-rs@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)":
+  "@astrojs/compiler-rs@0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)":
     dependencies:
-      "@astrojs/compiler-binding": 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      "@astrojs/compiler-binding": 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
     transitivePeerDependencies:
       - "@emnapi/core"
       - "@emnapi/runtime"
@@ -6401,13 +6406,13 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.5
 
-  "@astrojs/mdx@7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))":
+  "@astrojs/mdx@7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))":
     dependencies:
       "@astrojs/internal-helpers": 0.10.1
       "@astrojs/markdown-remark": 7.2.1
       "@mdx-js/mdx": 3.1.1
       acorn: 8.17.0
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
       es-module-lexer: 2.1.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -6438,22 +6443,22 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  "@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))(tailwindcss@4.2.4)":
+  "@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))(tailwindcss@4.2.4)":
     dependencies:
-      "@astrojs/starlight": 0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)
+      "@astrojs/starlight": 0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)
       tailwindcss: 4.2.4
 
-  "@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)":
+  "@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)":
     dependencies:
       "@astrojs/markdown-satteri": 0.3.4
-      "@astrojs/mdx": 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))
+      "@astrojs/mdx": 7.0.3(@astrojs/markdown-satteri@0.3.4)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))
       "@astrojs/sitemap": 3.7.2
       "@pagefind/default-ui": 1.4.0
       "@types/hast": 3.0.4
       "@types/js-yaml": 4.0.9
       "@types/mdast": 4.0.4
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
-      astro-expressive-code: 0.44.1(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
+      astro-expressive-code: 0.44.1(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -6592,7 +6597,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/runtime@1.11.2":
+  "@emnapi/runtime@1.11.3":
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6721,108 +6726,108 @@ snapshots:
 
   "@img/colour@1.1.0": {}
 
-  "@img/sharp-darwin-arm64@0.35.0":
+  "@img/sharp-darwin-arm64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-darwin-arm64": 1.3.0
+      "@img/sharp-libvips-darwin-arm64": 1.3.2
     optional: true
 
-  "@img/sharp-darwin-x64@0.35.0":
+  "@img/sharp-darwin-x64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-darwin-x64": 1.3.0
+      "@img/sharp-libvips-darwin-x64": 1.3.2
     optional: true
 
-  "@img/sharp-freebsd-wasm32@0.35.0":
+  "@img/sharp-freebsd-wasm32@0.35.3":
     dependencies:
-      "@img/sharp-wasm32": 0.35.0
+      "@img/sharp-wasm32": 0.35.3
     optional: true
 
-  "@img/sharp-libvips-darwin-arm64@1.3.0":
+  "@img/sharp-libvips-darwin-arm64@1.3.2":
     optional: true
 
-  "@img/sharp-libvips-darwin-x64@1.3.0":
+  "@img/sharp-libvips-darwin-x64@1.3.2":
     optional: true
 
-  "@img/sharp-libvips-linux-arm64@1.3.0":
+  "@img/sharp-libvips-linux-arm64@1.3.2":
     optional: true
 
-  "@img/sharp-libvips-linux-arm@1.3.0":
+  "@img/sharp-libvips-linux-arm@1.3.2":
     optional: true
 
-  "@img/sharp-libvips-linux-ppc64@1.3.0":
+  "@img/sharp-libvips-linux-ppc64@1.3.2":
     optional: true
 
-  "@img/sharp-libvips-linux-riscv64@1.3.0":
+  "@img/sharp-libvips-linux-riscv64@1.3.2":
     optional: true
 
-  "@img/sharp-libvips-linux-s390x@1.3.0":
+  "@img/sharp-libvips-linux-s390x@1.3.2":
     optional: true
 
-  "@img/sharp-libvips-linux-x64@1.3.0":
+  "@img/sharp-libvips-linux-x64@1.3.2":
     optional: true
 
-  "@img/sharp-libvips-linuxmusl-arm64@1.3.0":
+  "@img/sharp-libvips-linuxmusl-arm64@1.3.2":
     optional: true
 
-  "@img/sharp-libvips-linuxmusl-x64@1.3.0":
+  "@img/sharp-libvips-linuxmusl-x64@1.3.2":
     optional: true
 
-  "@img/sharp-linux-arm64@0.35.0":
+  "@img/sharp-linux-arm64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-linux-arm64": 1.3.0
+      "@img/sharp-libvips-linux-arm64": 1.3.2
     optional: true
 
-  "@img/sharp-linux-arm@0.35.0":
+  "@img/sharp-linux-arm@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-linux-arm": 1.3.0
+      "@img/sharp-libvips-linux-arm": 1.3.2
     optional: true
 
-  "@img/sharp-linux-ppc64@0.35.0":
+  "@img/sharp-linux-ppc64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-linux-ppc64": 1.3.0
+      "@img/sharp-libvips-linux-ppc64": 1.3.2
     optional: true
 
-  "@img/sharp-linux-riscv64@0.35.0":
+  "@img/sharp-linux-riscv64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-linux-riscv64": 1.3.0
+      "@img/sharp-libvips-linux-riscv64": 1.3.2
     optional: true
 
-  "@img/sharp-linux-s390x@0.35.0":
+  "@img/sharp-linux-s390x@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-linux-s390x": 1.3.0
+      "@img/sharp-libvips-linux-s390x": 1.3.2
     optional: true
 
-  "@img/sharp-linux-x64@0.35.0":
+  "@img/sharp-linux-x64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-linux-x64": 1.3.0
+      "@img/sharp-libvips-linux-x64": 1.3.2
     optional: true
 
-  "@img/sharp-linuxmusl-arm64@0.35.0":
+  "@img/sharp-linuxmusl-arm64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-arm64": 1.3.0
+      "@img/sharp-libvips-linuxmusl-arm64": 1.3.2
     optional: true
 
-  "@img/sharp-linuxmusl-x64@0.35.0":
+  "@img/sharp-linuxmusl-x64@0.35.3":
     optionalDependencies:
-      "@img/sharp-libvips-linuxmusl-x64": 1.3.0
+      "@img/sharp-libvips-linuxmusl-x64": 1.3.2
     optional: true
 
-  "@img/sharp-wasm32@0.35.0":
+  "@img/sharp-wasm32@0.35.3":
     dependencies:
-      "@emnapi/runtime": 1.11.2
+      "@emnapi/runtime": 1.11.3
     optional: true
 
-  "@img/sharp-webcontainers-wasm32@0.35.0":
+  "@img/sharp-webcontainers-wasm32@0.35.3":
     dependencies:
-      "@img/sharp-wasm32": 0.35.0
+      "@img/sharp-wasm32": 0.35.3
     optional: true
 
-  "@img/sharp-win32-arm64@0.35.0":
+  "@img/sharp-win32-arm64@0.35.3":
     optional: true
 
-  "@img/sharp-win32-ia32@0.35.0":
+  "@img/sharp-win32-ia32@0.35.3":
     optional: true
 
-  "@img/sharp-win32-x64@0.35.0":
+  "@img/sharp-win32-x64@0.35.3":
     optional: true
 
   "@jridgewell/gen-mapping@0.3.13":
@@ -6885,10 +6890,10 @@ snapshots:
       "@tybys/wasm-util": 0.10.3
     optional: true
 
-  "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)":
+  "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)":
     dependencies:
       "@emnapi/core": 1.11.1
-      "@emnapi/runtime": 1.11.2
+      "@emnapi/runtime": 1.11.3
       "@tybys/wasm-util": 0.10.3
     optional: true
 
@@ -7643,15 +7648,15 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.1(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)):
+  astro-expressive-code@0.44.1(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)):
     dependencies:
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
       rehype-expressive-code: 0.44.1
       url-extras: 0.1.0
 
-  astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3):
+  astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3):
     dependencies:
-      "@astrojs/compiler-rs": 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)
+      "@astrojs/compiler-rs": 0.3.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)
       "@astrojs/internal-helpers": 0.10.1
       "@astrojs/markdown-satteri": 0.3.4
       "@astrojs/telemetry": 3.3.3
@@ -7706,7 +7711,7 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       "@astrojs/markdown-remark": 7.2.1
-      sharp: 0.35.0
+      sharp: 0.35.3(@types/node@24.12.2)
     transitivePeerDependencies:
       - "@azure/app-configuration"
       - "@azure/cosmos"
@@ -9742,37 +9747,38 @@ snapshots:
 
   semver@7.8.5: {}
 
-  sharp@0.35.0:
+  sharp@0.35.3(@types/node@24.12.2):
     dependencies:
       "@img/colour": 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      "@img/sharp-darwin-arm64": 0.35.0
-      "@img/sharp-darwin-x64": 0.35.0
-      "@img/sharp-freebsd-wasm32": 0.35.0
-      "@img/sharp-libvips-darwin-arm64": 1.3.0
-      "@img/sharp-libvips-darwin-x64": 1.3.0
-      "@img/sharp-libvips-linux-arm": 1.3.0
-      "@img/sharp-libvips-linux-arm64": 1.3.0
-      "@img/sharp-libvips-linux-ppc64": 1.3.0
-      "@img/sharp-libvips-linux-riscv64": 1.3.0
-      "@img/sharp-libvips-linux-s390x": 1.3.0
-      "@img/sharp-libvips-linux-x64": 1.3.0
-      "@img/sharp-libvips-linuxmusl-arm64": 1.3.0
-      "@img/sharp-libvips-linuxmusl-x64": 1.3.0
-      "@img/sharp-linux-arm": 0.35.0
-      "@img/sharp-linux-arm64": 0.35.0
-      "@img/sharp-linux-ppc64": 0.35.0
-      "@img/sharp-linux-riscv64": 0.35.0
-      "@img/sharp-linux-s390x": 0.35.0
-      "@img/sharp-linux-x64": 0.35.0
-      "@img/sharp-linuxmusl-arm64": 0.35.0
-      "@img/sharp-linuxmusl-x64": 0.35.0
-      "@img/sharp-webcontainers-wasm32": 0.35.0
-      "@img/sharp-win32-arm64": 0.35.0
-      "@img/sharp-win32-ia32": 0.35.0
-      "@img/sharp-win32-x64": 0.35.0
+      "@img/sharp-darwin-arm64": 0.35.3
+      "@img/sharp-darwin-x64": 0.35.3
+      "@img/sharp-freebsd-wasm32": 0.35.3
+      "@img/sharp-libvips-darwin-arm64": 1.3.2
+      "@img/sharp-libvips-darwin-x64": 1.3.2
+      "@img/sharp-libvips-linux-arm": 1.3.2
+      "@img/sharp-libvips-linux-arm64": 1.3.2
+      "@img/sharp-libvips-linux-ppc64": 1.3.2
+      "@img/sharp-libvips-linux-riscv64": 1.3.2
+      "@img/sharp-libvips-linux-s390x": 1.3.2
+      "@img/sharp-libvips-linux-x64": 1.3.2
+      "@img/sharp-libvips-linuxmusl-arm64": 1.3.2
+      "@img/sharp-libvips-linuxmusl-x64": 1.3.2
+      "@img/sharp-linux-arm": 0.35.3
+      "@img/sharp-linux-arm64": 0.35.3
+      "@img/sharp-linux-ppc64": 0.35.3
+      "@img/sharp-linux-riscv64": 0.35.3
+      "@img/sharp-linux-s390x": 0.35.3
+      "@img/sharp-linux-x64": 0.35.3
+      "@img/sharp-linuxmusl-arm64": 0.35.3
+      "@img/sharp-linuxmusl-x64": 0.35.3
+      "@img/sharp-webcontainers-wasm32": 0.35.3
+      "@img/sharp-win32-arm64": 0.35.3
+      "@img/sharp-win32-ia32": 0.35.3
+      "@img/sharp-win32-x64": 0.35.3
+      "@types/node": 24.12.2
 
   shiki@4.0.2:
     dependencies:
@@ -9822,17 +9828,17 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-auto-sidebar@0.4.0(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)):
+  starlight-auto-sidebar@0.4.0(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)):
     dependencies:
-      "@astrojs/starlight": 0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)
+      "@astrojs/starlight": 0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)
       github-slugger: 2.0.0
 
-  starlight-links-validator@0.25.2(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)):
+  starlight-links-validator@0.25.2(@astrojs/starlight@0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3))(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)):
     dependencies:
       "@astrojs/markdown-satteri": 0.3.4
-      "@astrojs/starlight": 0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)
+      "@astrojs/starlight": 0.41.4(@astrojs/markdown-remark@7.2.1)(astro@7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3))(typescript@5.9.3)
       "@types/picomatch": 4.0.3
-      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
+      astro: 7.1.3(@astrojs/markdown-remark@7.2.1)(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.3)(@types/node@24.12.2)(jiti@2.6.1)(rollup@4.50.1)(yaml@2.8.3)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       is-absolute-url: 5.0.0


### PR DESCRIPTION
Updates the resolved Sharp version from 0.35.0 to 0.35.3 while preserving the compatible
`^0.35.0` manifest requirement.

This replaces the stale Dependabot PR that was closed after the Astro 7 upgrade merged. The
release improves bundler/libvips binary resolution and tightens validation around image
dimensions, regions, matrices, numeric values, and cache limits. It also adds `hasAlpha` output
metadata and a more precise TypeScript buffer return type.

Validation:

- lockfile installs with `--frozen-lockfile`
- repository formatting passes

No application source files change.
