### PR TITLE
Use page media for link previews (#1152)

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -46,15 +46,8 @@ export default defineConfig({
         replacesTitle: true,
       },
       favicon: "/favicon-32.png",
-      head: [
-        {
-          tag: "meta",
-          attrs: {
-            property: "og:image",
-            content: "/ratatui-og.png",
-          },
-        },
-      ],
+      // Note: `og:image` and the other link preview tags are set per page in
+      // `src/components/Head.astro` so that pages can preview their own featured media.
       components: {
         Head: "./src/components/Head.astro",
         Header: "./src/components/Header.astro",

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -48,15 +48,8 @@ export default defineConfig({
         replacesTitle: true,
       },
       favicon: "/favicon-32.png",
-      head: [
-        {
-          tag: "meta",
-          attrs: {
-            property: "og:image",
-            content: "/ratatui-og.png",
-          },
-        },
-      ],
+      // Note: `og:image` and the other link preview tags are set per page in
+      // `src/components/Head.astro` so that pages can preview their own featured media.
       components: {
         Head: "./src/components/Head.astro",
         Header: "./src/components/Header.astro",

--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -1,8 +1,19 @@
 ---
 import Default from "@astrojs/starlight/components/Head.astro";
+import { getOgImage } from "~/utils/ogImage";
+
+const { entry } = Astro.locals.starlightRoute;
+const ogImage = await getOgImage({ ...entry, site: Astro.site });
 ---
 
 <Default><slot /></Default>
+
+<meta property="og:image" content={ogImage.url} />
+<meta name="twitter:image" content={ogImage.url} />
+{ogImage.alt && <meta property="og:image:alt" content={ogImage.alt} />}
+{ogImage.alt && <meta name="twitter:image:alt" content={ogImage.alt} />}
+{ogImage.width && <meta property="og:image:width" content={String(ogImage.width)} />}
+{ogImage.height && <meta property="og:image:height" content={String(ogImage.height)} />}
 
 <script
   is:inline

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,11 +1,25 @@
 import { docsLoader } from "@astrojs/starlight/loaders";
 import { docsSchema } from "@astrojs/starlight/schema";
-import { defineCollection } from "astro:content";
+import { defineCollection, z } from "astro:content";
 import { autoSidebarLoader } from "starlight-auto-sidebar/loader";
 import { autoSidebarSchema } from "starlight-auto-sidebar/schema";
 
 export const collections = {
-  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({
+    loader: docsLoader(),
+    schema: docsSchema({
+      extend: ({ image }) =>
+        z.object({
+          /**
+           * Image used for link previews (Open Graph / Twitter cards).
+           *
+           * Either a path to a local image, or the URL of a remote one. Defaults to the first
+           * image on the page, falling back to the site-wide preview image.
+           */
+          ogImage: z.union([image(), z.string()]).optional(),
+        }),
+    }),
+  }),
   autoSidebar: defineCollection({
     loader: autoSidebarLoader(),
     schema: autoSidebarSchema(),

--- a/src/content/docs/developer-guide/website.mdx
+++ b/src/content/docs/developer-guide/website.mdx
@@ -79,6 +79,22 @@ See [starlight] for more information on how to author content in markdown.
 
 [starlight]: https://starlight.astro.build/guides/authoring-content/
 
+## Link previews
+
+Every page has Open Graph and Twitter card metadata so that links shared on social platforms show a
+preview image. The image is the first image on the page (e.g. the animation at the top of a release
+highlights page), falling back to the site-wide preview image for pages without images.
+
+To choose a different image, set `ogImage` in the page frontmatter to a path relative to the page,
+or to the URL of a remote image:
+
+```yaml
+---
+title: v0.30.0
+ogImage: ../../../assets/ratatui-animation.gif
+---
+```
+
 ## Custom components
 
 The website uses custom components and features to make it easier to generate high quality

--- a/src/utils/ogImage.test.ts
+++ b/src/utils/ogImage.test.ts
@@ -1,0 +1,134 @@
+import dedent from "ts-dedent";
+import { describe, expect, test } from "vitest";
+import { getOgImage } from "./ogImage";
+
+const site = new URL("https://ratatui.rs");
+const filePath = "src/content/docs/highlights/v0.30.md";
+
+const page = (body: string, data: Record<string, unknown> = {}) => ({
+  body,
+  filePath,
+  site,
+  data: { title: "v0.30.0", ...data },
+});
+
+describe("getOgImage", () => {
+  test("falls back to the site image when the page has no images", async () => {
+    const image = await getOgImage(page("Just some text."));
+    expect(image.url).toBe("https://ratatui.rs/ratatui-og.png");
+  });
+
+  test("uses the first image in the page", async () => {
+    const image = await getOgImage(
+      page(dedent`
+        ![animation](https://example.com/animation.gif)
+
+        ![screenshot](https://example.com/screenshot.png)
+      `),
+    );
+    expect(image).toEqual({ url: "https://example.com/animation.gif", alt: "animation" });
+  });
+
+  test("uses the page title when an image has no alt text", async () => {
+    const image = await getOgImage(page("![](https://example.com/animation.gif)"));
+    expect(image.alt).toBe("v0.30.0");
+  });
+
+  test("supports HTML images", async () => {
+    const image = await getOgImage(
+      page(`<img src="https://example.com/demo.png" alt="demo" width="100" />`),
+    );
+    expect(image).toEqual({ url: "https://example.com/demo.png", alt: "demo" });
+  });
+
+  test("ignores images inside code blocks", async () => {
+    const image = await getOgImage(
+      page(dedent`
+        \`\`\`markdown
+        ![example](https://example.com/example.png)
+        \`\`\`
+
+        ![real](https://example.com/real.png)
+      `),
+    );
+    expect(image.url).toBe("https://example.com/real.png");
+  });
+
+  test("ignores images in a code block containing a nested fence", async () => {
+    const image = await getOgImage(
+      page(dedent`
+        \`\`\`\`markdown
+        \`\`\`rust
+        // example
+        \`\`\`
+        ![example](https://example.com/example.png)
+        \`\`\`\`
+
+        ![real](https://example.com/real.png)
+      `),
+    );
+    expect(image.url).toBe("https://example.com/real.png");
+  });
+
+  test("skips badges and SVGs, which don't render in link previews", async () => {
+    const image = await getOgImage(
+      page(dedent`
+        ![crates.io](https://img.shields.io/crates/v/ratatui)
+        ![logo](https://example.com/logo.svg)
+        ![demo](https://example.com/demo.gif)
+      `),
+    );
+    expect(image.url).toBe("https://example.com/demo.gif");
+  });
+
+  test("skips protocol-relative badges", async () => {
+    const image = await getOgImage(
+      page(dedent`
+        ![crates.io](//img.shields.io/crates/v/ratatui)
+        ![demo](//example.com/demo.gif)
+      `),
+    );
+    expect(image.url).toBe("https://example.com/demo.gif");
+  });
+
+  test("falls back when a page-relative image isn't a bundled asset", async () => {
+    const image = await getOgImage(page("![missing](./missing.png)"));
+    expect(image.url).toBe("https://ratatui.rs/ratatui-og.png");
+  });
+
+  test("resolves images served from the site root", async () => {
+    const image = await getOgImage(page("![csvlens](/csvlens.gif)"));
+    expect(image.url).toBe("https://ratatui.rs/csvlens.gif");
+  });
+
+  test("resolves bundled images referenced relative to the page", async () => {
+    const image = await getOgImage(page("![animation](../../../assets/ratatui-animation.gif)"));
+    // The exact URL depends on how Astro emits the asset (hashed in builds, `/@fs/…` in dev).
+    expect(image.url).toMatch(/^https:\/\/ratatui\.rs\/.*ratatui-animation.*\.gif/);
+    expect(image.width).toBe(1280);
+    expect(image.height).toBe(640);
+  });
+
+  test("prefers the ogImage frontmatter over images in the page", async () => {
+    const image = await getOgImage(
+      page("![animation](https://example.com/animation.gif)", {
+        ogImage: "https://example.com/custom.png",
+      }),
+    );
+    expect(image).toEqual({ url: "https://example.com/custom.png", alt: "v0.30.0" });
+  });
+
+  test("supports ogImage frontmatter pointing at a bundled image", async () => {
+    const image = await getOgImage(
+      page("Just some text.", {
+        ogImage: { src: "/_astro/hero.hash.png", width: 1200, height: 630, format: "png" },
+      }),
+    );
+    expect(image).toEqual({
+      url: "https://ratatui.rs/_astro/hero.hash.png",
+      width: 1200,
+      height: 630,
+      alt: "v0.30.0",
+    });
+  });
+});

--- a/src/utils/ogImage.ts
+++ b/src/utils/ogImage.ts
@@ -1,0 +1,155 @@
+import type { ImageMetadata } from "astro";
+
+/** Fallback image used when a page has no featured media of its own. */
+const DEFAULT_OG_IMAGE = "/ratatui-og.png";
+
+/** Local images that pages may reference, loaded lazily so unused ones aren't processed. */
+const localImages = import.meta.glob<{ default: ImageMetadata }>([
+  "/src/assets/**/*.{png,jpg,jpeg,gif,webp,avif}",
+  "/src/content/**/*.{png,jpg,jpeg,gif,webp,avif}",
+]);
+
+export interface OgImage {
+  url: string;
+  alt?: string;
+  width?: number;
+  height?: number;
+}
+
+/** Images that make poor link previews: badges and formats social platforms don't render. */
+function isUsable(src: string): boolean {
+  const url = src.startsWith("//") ? `https:${src}` : src;
+  const path = url.split(/[?#]/, 1)[0] ?? "";
+  if (/\.svgz?$/i.test(path)) return false;
+  return !/^https?:\/\/(img\.shields\.io|badgen\.net|badge\.fury\.io)\//i.test(url);
+}
+
+/**
+ * Remove fenced code blocks so that example snippets don't provide the preview image.
+ *
+ * A fence is only closed by at least as many of the same character it was opened with, so a block
+ * opened with ```` ```` ```` isn't ended by a ```` ``` ```` line inside it.
+ */
+function stripCodeFences(body: string): string {
+  const lines: string[] = [];
+  let fence: string | undefined;
+
+  for (const line of body.split("\n")) {
+    const marker = line.match(/^ {0,3}(`{3,}|~{3,})/)?.[1];
+    if (fence === undefined) {
+      if (marker) fence = marker;
+      else lines.push(line);
+    } else if (
+      marker &&
+      marker[0] === fence[0] &&
+      marker.length >= fence.length &&
+      // A closing fence carries nothing but the fence itself.
+      line.trimEnd().length === line.indexOf(marker) + marker.length
+    ) {
+      fence = undefined;
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/** Markdown (`![alt](src)`) and HTML (`<img src="…">`) images in a page body, in order. */
+function findImages(body: string): { src: string; alt: string }[] {
+  const content = stripCodeFences(body);
+
+  const pattern =
+    /!\[([^\]]*)\]\(\s*<?([^\s)>]+)>?(?:\s+["'][^"']*["'])?\s*\)|<img\b[^>]*?\bsrc\s*=\s*["']([^"']+)["'][^>]*>/gi;
+
+  const images: { src: string; alt: string }[] = [];
+  for (const [tag, markdownAlt, markdownSrc, htmlSrc] of content.matchAll(pattern)) {
+    const src = markdownSrc ?? htmlSrc;
+    if (!src || !isUsable(src)) continue;
+    const alt = markdownSrc ? markdownAlt : tag.match(/\balt\s*=\s*["']([^"']*)["']/i)?.[1];
+    images.push({ src, alt: alt ?? "" });
+  }
+  return images;
+}
+
+/** Resolve a path relative to a file, e.g. `("src/content/docs/a/b.md", "../c.png")`. */
+function resolveRelative(filePath: string, src: string): string {
+  const segments = `/${filePath}`.split("/").slice(0, -1).concat(src.split("/"));
+  const resolved: string[] = [];
+  for (const segment of segments) {
+    if (segment === "" || segment === ".") continue;
+    if (segment === "..") resolved.pop();
+    else resolved.push(segment);
+  }
+  return `/${resolved.join("/")}`;
+}
+
+/**
+ * Resolve an image reference from a page body into an absolute URL.
+ *
+ * Remote images are used as-is, root-relative paths are resolved against the site URL, and paths
+ * relative to the page source are looked up in the bundled assets so that the built (hashed) URL
+ * is used.
+ */
+async function resolveImage(
+  src: string,
+  filePath: string,
+  site: URL | undefined,
+): Promise<Omit<OgImage, "alt"> | undefined> {
+  if (/^https?:\/\//i.test(src)) return { url: src };
+  if (src.startsWith("//")) return { url: `https:${src}` };
+  if (src.startsWith("data:")) return undefined;
+
+  const isRootRelative = src.startsWith("/");
+  const path = isRootRelative ? src : resolveRelative(filePath, src);
+
+  const loadImage = localImages[path];
+  if (!loadImage) {
+    // Root-relative paths are images shipped in `public/`, served from the site root as-is.
+    // Anything else failed to resolve to a bundled asset, so there is no URL worth advertising.
+    return isRootRelative && site ? { url: new URL(path, site).href } : undefined;
+  }
+
+  const { default: image } = await loadImage();
+  return {
+    url: site ? new URL(image.src, site).href : image.src,
+    width: image.width,
+    height: image.height,
+  };
+}
+
+/**
+ * Get the Open Graph image for a page.
+ *
+ * Pages can set an `ogImage` in their frontmatter. Otherwise the first image in the page is used,
+ * so that release highlights and showcase pages preview their own animations and screenshots. Pages
+ * without any image fall back to the site-wide Open Graph image.
+ */
+export async function getOgImage(entry: {
+  body?: string;
+  filePath?: string;
+  data: { title?: string; ogImage?: ImageMetadata | string };
+  site?: URL;
+}): Promise<OgImage> {
+  const { body = "", filePath = "", data, site } = entry;
+  const fallback = { url: site ? new URL(DEFAULT_OG_IMAGE, site).href : DEFAULT_OG_IMAGE };
+
+  const frontmatter = data.ogImage;
+  if (frontmatter) {
+    if (typeof frontmatter === "string") {
+      const resolved = await resolveImage(frontmatter, filePath, site);
+      return { ...(resolved ?? fallback), alt: data.title };
+    }
+    return {
+      url: site ? new URL(frontmatter.src, site).href : frontmatter.src,
+      width: frontmatter.width,
+      height: frontmatter.height,
+      alt: data.title,
+    };
+  }
+
+  for (const image of findImages(body)) {
+    const resolved = await resolveImage(image.src, filePath, site);
+    if (resolved) return { ...resolved, alt: image.alt || data.title };
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Details

Every page shared the same `og:image`, so links to release highlights and other pages with featured media previewed as generic site cards.

Set the Open Graph and Twitter card image per page: pages can point at one with the new `ogImage` frontmatter, otherwise the first image on the page is used (skipping code blocks, badges and SVGs), falling back to the site-wide image for pages without any images. Local images resolve to their built URLs so that width and height can be advertised too.

Fixes: #1152 

<!-- Please read CONTRIBUTING.md before submitting any pull request. -->

<!--
If this PR adds or updates a showcase app or third-party widget, please open a showcase submission
issue first so we can discuss fit and presentation before review:

https://github.com/ratatui/ratatui-website/issues/new?template=showcase-submission.yml

Also read:
- https://ratatui.rs/recipes/apps/submitting-to-the-showcase/
- https://ratatui.rs/recipes/apps/release-your-app/

When you open the PR, link back to the showcase submission issue.
-->
