### PR TITLE
Add ratcn to the ecosystem overview

### DIFF
--- a/src/assets/ratcn.gif
+++ b/src/assets/ratcn.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:503cce25faa401c7c210365d8852be43f93eac663fe45cf3d2ac06e005020a30
+size 5420531

--- a/src/content/docs/ecosystem/ratcn.md
+++ b/src/content/docs/ecosystem/ratcn.md
@@ -1,0 +1,24 @@
+---
+title: Component libraries
+sidebar:
+  order: 5
+---
+
+## ratcn
+
+> Themeable terminal UI components for Ratatui, inspired by shadcn/ui.
+
+![ratcn demo](../../../assets/ratcn.gif)
+
+Ratcn provides themeable buttons, lists, tabs, dialogs, and other components for Ratatui. Use the components directly from the crate, or copy and customize their source with the
+`cargo ratcn add` command.
+
+An optional runtime handles focus, hover, and keyboard and mouse event routing. Your application
+keeps full control of its state and event loop.
+
+Explore the [interactive demos](https://ratcn.com/docs/demos) in your browser, or try the showcase
+in your terminal with `ssh ratcn.com`.
+
+- [Getting Started](https://ratcn.com/docs/getting-started)
+- [API Documentation](https://docs.rs/ratcn/)
+- [GitHub](https://github.com/kristoferlund/ratcn)

--- a/src/content/docs/ecosystem/ratcn.md
+++ b/src/content/docs/ecosystem/ratcn.md
@@ -10,8 +10,9 @@ sidebar:
 
 ![ratcn demo](../../../assets/ratcn.gif)
 
-Ratcn provides themeable buttons, lists, tabs, dialogs, and other components for Ratatui. Use the components directly from the crate, or copy and customize their source with the
-`cargo ratcn add` command.
+Ratcn provides themeable buttons, lists, tabs, dialogs, and other components for Ratatui. Use the
+components directly from the crate, or copy and customize their source with the `cargo ratcn add`
+command.
 
 An optional runtime handles focus, hover, and keyboard and mouse event routing. Your application
 keeps full control of its state and event loop.


### PR DESCRIPTION
This PR adds ratcn to the newly created ecosystem category `Component libraries`. If you would rather see ratcn in the third party widgets section just let me know. 

@orhun 